### PR TITLE
Fix test client and add missing imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual Environment
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.hypothesis/
+
+# Logs
+*.log
+logs/
+
+# MCP/Server
+*.pid
+*.sock
+
+# Temporary files
+*.tmp
+*.bak
+*.cache

--- a/observability/telemetry.py
+++ b/observability/telemetry.py
@@ -10,6 +10,7 @@ All data is visible in Jaeger for analysis.
 """
 
 import json
+import sys
 from typing import Any
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,19 +19,18 @@ async def test_server():
             print(f"   - {tool.name}")
         print(f"\n   Total: {len(tools)} tools\n")
 
-        # Test 2: Call know_about_mospi_api
-        print("🔍 Testing know_about_mospi_api...")
-        result = await client.call_tool("know_about_mospi_api", {})
+        # Test 2: Call 1_know_about_mospi_api
+        print("🔍 Testing 1_know_about_mospi_api...")
+        result = await client.call_tool("1_know_about_mospi_api", {})
         print(f"   ✅ Success! Got {len(str(result))} characters of documentation\n")
 
-        # Test 3: Call lookup_mospi_codes
-        print("🔍 Testing lookup_mospi_codes...")
+        # Test 3: Call 2_get_indicators
+        print("🔍 Testing 2_get_indicators...")
         result = await client.call_tool(
-            "lookup_mospi_codes",
+            "2_get_indicators",
             {
                 "dataset": "PLFS",
-                "category": "State",
-                "search_term": "rajasthan"
+                "user_query": "test query"
             }
         )
         print(f"   ✅ Success! Result: {result}\n")


### PR DESCRIPTION
fix #1 



### Changes

1. **Fixed test client tool names** (`tests/test_client.py`)
   - Changed `know_about_mospi_api` to `1_know_about_mospi_api` to match the server tool name
   - Replaced non-existent `lookup_mospi_codes` test with `2_get_indicators` test
   - Updated test parameters to match the actual tool signature

2. **Fixed missing import in telemetry middleware** (`observability/telemetry.py`)
   - Added missing `import sys` statement
   - Fixes `ToolError: name 'sys' is not defined` when tools are called
   - The middleware uses `sys.stderr` on line 110 but was missing the import

3. **Added `.gitignore` file**
   - Ignores Python artifacts (`__pycache__/`, `*.pyc`, etc.)
   - Ignores virtual environment directories (`venv/`, `env/`, etc.)
   - Ignores IDE files, environment files, and testing artifacts
   - Prevents committing unnecessary files to the repository

### Testing

- Test client now successfully connects and calls tools without errors

<img width="189" height="22" alt="Screenshot 2026-02-07 at 12 04 46 AM" src="https://github.com/user-attachments/assets/b20ac2c5-db1f-4279-a53f-c025492ae17f" />


- All tool calls execute properly with telemetry middleware enabled