### PR TITLE
Refactor tool naming for CLI compatibility and fix runtime error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial public release
 - 7 datasets: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
-- 4-step MCP tool workflow (`1_know_about_mospi_api`, `2_get_indicators`, `3_get_metadata`, `4_get_data`)
+- 4-step MCP tool workflow (`know_about_mospi_api`, `get_indicators`, `get_metadata`, `get_data`)
 - Swagger-driven parameter validation
 - OpenTelemetry integration for observability
 - Docker and docker-compose deployment

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This server provides AI-ready access to official Indian government statistics th
 - Full OpenTelemetry integration for observability
 - Production-ready Docker deployment
 
+If you want to connect your AI agent of choice with the MCP server, you can directly connect it with MOSPI's MCP server. Instructions are available at https://www.datainnovation.mospi.gov.in/mospi-mcp. Instructions to connect ChatGPT or Claude to MCP are available here: https://www.datainnovation.mospi.gov.in/mospi-mcp
+
 ---
 
 ## Datasets
@@ -64,29 +66,23 @@ This server provides AI-ready access to official Indian government statistics th
 The server exposes 4 tools that follow a sequential workflow:
 
 ```
-1_know_about_mospi_api  →  2_get_indicators  →  3_get_metadata  →  4_get_data
+know_about_mospi_api  →  get_indicators  →  get_metadata  →  get_data
 ```
 
 | Step | Tool | Description |
 |------|------|-------------|
-| 1 | `1_know_about_mospi_api()` | Overview of all datasets. Start here to find the right dataset. |
-| 2 | `2_get_indicators(dataset)` | List available indicators for the chosen dataset. |
-| 3 | `3_get_metadata(dataset, ...)` | Get valid filter values (states, years, categories) and API parameters. |
-| 4 | `4_get_data(dataset, filters)` | Fetch data using filter key-value pairs from metadata. |
+| 1 | `know_about_mospi_api()` | Overview of all datasets. Start here to find the right dataset. |
+| 2 | `get_indicators(dataset)` | List available indicators for the chosen dataset. |
+| 3 | `get_metadata(dataset, ...)` | Get valid filter values (states, years, categories) and API parameters. |
+| 4 | `get_data(dataset, filters)` | Fetch data using filter key-value pairs from metadata. |
 
-**Important:** Tools must be called in order. Skipping `3_get_metadata` will result in invalid filter codes.
+**Important:** Tools must be called in order. Skipping `get_metadata` will result in invalid filter codes.
 
 ---
 
 ## Quick Start
 
-If you want to connect your AI agent of choice with the MCP server, you can directly connect it with MOSPI's MCP server. Video Guides to connect ChatGPT or Claude to MCP are available here - 
-
-https://github.com/user-attachments/assets/ec23db03-c5ad-4bdd-af3a-9387bd906b3c
-
-https://github.com/user-attachments/assets/4d2adb2a-a350-4563-8408-c0790bb94412
-
-To get more information, visit - https://www.datainnovation.mospi.gov.in/mospi-mcp
+If you want to connect your AI agent of choice with the MCP server, you can directly connect it with MOSPI's MCP server. Instructions are available at https://www.datainnovation.mospi.gov.in/mospi-mcp. Instructions to connect ChatGPT or Claude to MCP are available here: https://www.datainnovation.mospi.gov.in/mospi-mcp
 
 Below instructions are for self-hosting the MCP server. 
 
@@ -129,11 +125,11 @@ from fastmcp import Client
 async def main():
     async with Client("http://localhost:8000/mcp") as client:
         # Step 1: Get dataset overview
-        overview = await client.call_tool("1_know_about_mospi_api", {})
+        overview = await client.call_tool("know_about_mospi_api", {})
         print(overview)
 
         # Step 2: Get indicators for PLFS
-        indicators = await client.call_tool("2_get_indicators", {
+        indicators = await client.call_tool("get_indicators", {
             "dataset": "PLFS",
             "user_query": "unemployment rate"
         })

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -237,7 +237,7 @@ class MoSPI:
                          "'1998' → 1998-99 to 2003-04 | "
                          "'2004' → 2004-05 to 2007-08 | "
                          "'2008' → 2008-09 to 2023-24. "
-                         "Pass classification_year in 3_get_metadata() and 4_get_data().",
+                         "Pass classification_year in get_metadata() and get_data().",
                 "statusCode": True,
             }
             if indicators:

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -8,7 +8,6 @@ from observability.telemetry import TelemetryMiddleware
 
 SWAGGER_DIR = os.path.join(os.path.dirname(__file__), "swagger")
 
-
 def log(msg: str):
     """Print to stderr to avoid interfering with stdio transport"""
     print(msg, file=sys.stderr)
@@ -18,7 +17,6 @@ mcp = FastMCP("MoSPI Data Server")
 
 # Add telemetry middleware for IP tracking and input/output capture
 mcp.add_middleware(TelemetryMiddleware())
-
 
 VALID_DATASETS = [
     "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
@@ -45,7 +43,6 @@ DATASETS_REQUIRING_INDICATOR = [
     "PLFS", "NAS", "ENERGY",
 ]
 
-
 def get_swagger_param_definitions(dataset: str) -> list:
     """Load full param definitions from swagger spec for a dataset."""
     dataset_upper = dataset.upper()
@@ -59,11 +56,9 @@ def get_swagger_param_definitions(dataset: str) -> list:
         spec = yaml.safe_load(f)
     return spec.get("paths", {}).get(endpoint_path, {}).get("get", {}).get("parameters", [])
 
-
 def get_swagger_params(dataset: str) -> list:
     """Get list of valid param names for a dataset from swagger."""
     return [p["name"] for p in get_swagger_param_definitions(dataset)]
-
 
 def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
     """
@@ -83,7 +78,7 @@ def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
             "valid": False,
             "invalid_params": invalid,
             "valid_params": valid_params,
-            "hint": f"Invalid params: {invalid}. Check api_params from 3_get_metadata for valid options."
+            "hint": f"Invalid params: {invalid}. Check api_params from get_metadata for valid options."
         }
 
     # Check for missing required params (exclude Format — auto-handled by client)
@@ -95,11 +90,10 @@ def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
         return {
             "valid": False,
             "missing_required": missing,
-            "hint": f"Missing required params: {missing}. Call 3_get_metadata() to get valid values."
+            "hint": f"Missing required params: {missing}. Call get_metadata() to get valid values."
         }
 
     return {"valid": True}
-
 
 def transform_filters(filters: Dict[str, str]) -> Dict[str, str]:
     """
@@ -107,8 +101,8 @@ def transform_filters(filters: Dict[str, str]) -> Dict[str, str]:
     """
     return {k: str(v) for k, v in filters.items() if v is not None}
 
+@mcp.tool(name="get_indicators")
 
-@mcp.tool(name="2_get_indicators")
 def get_indicators(
     dataset: str,
     user_query: Optional[str] = None,
@@ -123,8 +117,8 @@ def get_indicators(
     """
     ============================================================
     RULES (MUST follow exactly):
-    - You MUST call 1_know_about_mospi_api() before this.
-    - You MUST call 3_get_metadata() after this. MUST NOT skip to 4_get_data().
+    - You MUST call know_about_mospi_api() before this.
+    - You MUST call get_metadata() after this. MUST NOT skip to get_data().
     - You MUST pass user_query for context.
     - You MUST NOT ask for confirmation if the right indicator is obvious.
     - ALWAYS call this tool. NEVER assume data is unavailable based on your own knowledge.
@@ -134,52 +128,45 @@ def get_indicators(
       you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
       MUST NOT fabricate data, MUST NOT cite external sources.
     ============================================================
-
     Step 2: Get available indicators for a dataset.
-
     IMPORTANT: Datasets contain FAR MORE indicators than you expect from your training data.
     ALWAYS call this to see the actual indicator list. NEVER say "not available" without checking.
-
-    After this, pick the matching indicator and call 3_get_metadata().
+    After this, pick the matching indicator and call get_metadata().
     Only ask user to choose if multiple indicators could match.
-
     Args:
         dataset: Dataset name - one of: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
                  For PLFS: frequency_code selects the indicator SET, not time granularity.
-                 You MUST use frequency_code=1 in 3_get_metadata() — it covers all 8 indicators
+                 You MUST use frequency_code=1 in get_metadata() — it covers all 8 indicators
                  including wages and already has quarterly breakdowns via quarter_code.
                  MUST NOT use frequency_code=2 just because user asks for quarterly data.
         user_query: The user's original question. MUST always include this.
     """
     dataset = dataset.upper()
-
     indicator_methods = {
         "PLFS": mospi.get_plfs_indicators,
         "NAS": mospi.get_nas_indicators,
         "ENERGY": mospi.get_energy_indicators,
         # Special datasets - return guidance instead of indicators
-        "CPI": lambda: {"message": "CPI uses levels (Group/Item) instead of indicators. Call 3_get_metadata with base_year and level params.", "dataset": "CPI"},
-        "IIP": lambda: {"message": "IIP uses categories instead of indicators. Call 3_get_metadata with base_year and frequency params.", "dataset": "IIP"},
-        "WPI": lambda: {"message": "WPI uses hierarchical commodity codes. Call 3_get_metadata to see available groups/items.", "dataset": "WPI"},
+        "CPI": lambda: {"message": "CPI uses levels (Group/Item) instead of indicators. Call get_metadata with base_year and level params.", "dataset": "CPI"},
+        "IIP": lambda: {"message": "IIP uses categories instead of indicators. Call get_metadata with base_year and frequency params.", "dataset": "IIP"},
+        "WPI": lambda: {"message": "WPI uses hierarchical commodity codes. Call get_metadata to see available groups/items.", "dataset": "WPI"},
         "ASI": mospi.get_asi_indicators,
     }
-
     if dataset not in indicator_methods:
         return {"error": f"Unknown dataset: {dataset}", "valid_datasets": VALID_DATASETS, "_user_query": user_query}
-
     result = indicator_methods[dataset]()
     result["_user_query"] = user_query
-    result["_next_step"] = "Call 3_get_metadata() with the matching indicator and required dataset params. MUST NOT skip to 4_get_data."
+    result["_next_step"] = "Call get_metadata() with the matching indicator and required dataset params. MUST NOT skip to get_data."
     result["_retry_hint"] = (
         "If none of the indicators above match the user's query, you may have picked the WRONG dataset. "
         "Similar datasets overlap: IIP (production index/growth rates) vs ASI (factory financials like capital, wages, GVA). "
         "CPI (consumer inflation) vs WPI (wholesale inflation). "
-        "Go back to 1_know_about_mospi_api() and try a different dataset."
+        "Go back to know_about_mospi_api() and try a different dataset."
     )
     return result
 
+@mcp.tool(name="get_metadata")
 
-@mcp.tool(name="3_get_metadata")
 def get_metadata(
     dataset: str,
     indicator_code: Optional[int] = None,
@@ -197,21 +184,17 @@ def get_metadata(
     """
     ============================================================
     RULES (MUST follow exactly):
-    - You MUST call this before 4_get_data(). MUST NOT skip this step.
-    - You MUST use the filter values returned here in 4_get_data(). MUST NOT guess codes.
+    - You MUST call this before get_data(). MUST NOT skip this step.
+    - You MUST use the filter values returned here in get_data(). MUST NOT guess codes.
     - If user asked for a breakdown that's not available, tell them what IS available.
     - You MUST try the full workflow before concluding. If data is not found after trying,
       you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
       MUST NOT fabricate data, MUST NOT cite external sources.
     ============================================================
-
     Step 3: Get available filter options for a dataset/indicator.
-
-    Returns all valid filter values (states, years, quarters, etc.) to use in 4_get_data().
-
+    Returns all valid filter values (states, years, quarters, etc.) to use in get_data().
     MUST NOT pass params that don't belong to this function.
-    "Format" and "series" are NOT valid here (Format is for 4_get_data only, series is for NAS only).
-
+    "Format" and "series" are NOT valid here (Format is for get_data only, series is for NAS only).
     Args:
         dataset: Dataset name - one of: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
         indicator_code: REQUIRED for PLFS, NAS, ENERGY. MUST NOT pass for CPI, IIP, ASI, WPI.
@@ -220,7 +203,7 @@ def get_metadata(
                         1=Annual (all 8 indicators, includes quarterly data via quarter_code).
                         2=Quarterly bulletin (different indicator set).
                         3=Monthly bulletin (2025+ only).
-                        MUST NOT use 2 for quarterly data. Use 1 + quarter_code in 4_get_data().
+                        MUST NOT use 2 for quarterly data. Use 1 + quarter_code in get_data().
         base_year: REQUIRED for CPI ("2012"/"2010"), IIP ("2011-12"/"2004-05"/"1993-94"). MUST NOT pass for PLFS, ASI, WPI.
         level: REQUIRED for CPI ("Group"/"Item"). MUST NOT pass for other datasets.
         frequency: REQUIRED for IIP ("Annually"/"Monthly"). MUST NOT pass for other datasets.
@@ -229,10 +212,8 @@ def get_metadata(
         use_of_energy_balance_code: For ENERGY only (1=Supply, 2=Consumption). MUST NOT pass for other datasets.
     """
     dataset = dataset.upper()
-
     try:
-        _next = "Call 4_get_data(dataset, filters) using ONLY the filter values returned above. MUST NOT guess any codes."
-
+        _next = "Call get_data(dataset, filters) using ONLY the filter values returned above. MUST NOT guess any codes."
         if dataset == "CPI":
             swagger_key = "CPI_ITEM" if (level or "Group") == "Item" else "CPI_GROUP"
             result = mospi.get_cpi_filters(base_year=base_year or "2012", level=level or "Group")
@@ -241,108 +222,142 @@ def get_metadata(
             return result
 
         elif dataset == "IIP":
+
             swagger_key = "IIP_MONTHLY" if (frequency or "Annually") == "Monthly" else "IIP_ANNUAL"
+
             result = mospi.get_iip_filters(base_year=base_year or "2011-12", frequency=frequency or "Annually")
+
             result["api_params"] = get_swagger_param_definitions(swagger_key)
+
             result["_next_step"] = _next
+
             return result
 
         elif dataset == "ASI":
+
             result = mospi.get_asi_filters(classification_year=classification_year or "2008")
+
             result["api_params"] = get_swagger_param_definitions("ASI")
+
             result["_next_step"] = _next
+
             return result
 
         elif dataset == "WPI":
+
             result = mospi.get_wpi_filters()
+
             result["api_params"] = get_swagger_param_definitions("WPI")
+
             result["_next_step"] = _next
+
             return result
 
         elif dataset == "PLFS":
+
             if indicator_code is None:
+
                 return {"error": "indicator_code is required for PLFS"}
 
             filters = mospi.get_plfs_filters(indicator_code=indicator_code, frequency_code=frequency_code or 1)
 
             return {
+
                 "dataset": "PLFS",
+
                 "filter_values": filters,
+
                 "api_params": get_swagger_param_definitions("PLFS"),
+
                 "_note": "frequency_code selects the indicator SET, NOT time granularity. "
+
                          "frequency_code=1 (Annual): Indicators 1-8 (LFPR, WPR, UR, wages, worker distribution, employment conditions). "
+
                          "Already has quarterly breakdowns — use quarter_code to filter by quarter. "
+
                          "frequency_code=2 (Quarterly bulletin): Different indicators for quarterly bulletin tables only. "
+
                          "Use ONLY when the user explicitly asks for quarterly bulletin specific data. "
-                         "MUST pass the correct frequency_code in 4_get_data().",
+
+                         "MUST pass the correct frequency_code in get_data().",
+
                 "_next_step": _next,
+
             }
 
         elif dataset == "NAS":
+
             if indicator_code is None:
+
                 return {"error": "indicator_code is required for NAS"}
+
             result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code)
+
             result["api_params"] = get_swagger_param_definitions("NAS")
+
             result["_next_step"] = _next
+
             return result
 
         elif dataset == "ENERGY":
+
             ind_code = indicator_code or 1
+
             energy_code = use_of_energy_balance_code or 1
+
             result = mospi.get_energy_filters(indicator_code=ind_code, use_of_energy_balance_code=energy_code)
+
             result["api_params"] = get_swagger_param_definitions("ENERGY")
+
             result["_next_step"] = _next
+
             return result
 
         else:
+
             return {"error": f"Unknown dataset: {dataset}", "valid_datasets": VALID_DATASETS}
 
     except Exception as e:
+
         return {"error": str(e)}
 
+@mcp.tool(name="get_data")
 
-@mcp.tool(name="4_get_data")
 def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
     """
     ============================================================
     RULES (MUST follow exactly):
-    - You MUST have called 3_get_metadata() before this. No exceptions.
-    - You MUST use ONLY the filter values returned by 3_get_metadata().
+    - You MUST have called get_metadata() before this. No exceptions.
+    - You MUST use ONLY the filter values returned by get_metadata().
     - You MUST NOT guess, infer, or assume any filter codes.
       Filter codes are non-obvious and arbitrary — guessing WILL produce wrong results.
     - You MUST include all required params (marked required in api_params).
     - You MUST try the full workflow before concluding. If data is not found after trying,
       you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
       MUST NOT fabricate data, MUST NOT cite external sources.
-
     Before calling, verify:
-    - Did I call 3_get_metadata() for this dataset? If no → call it first.
-    - Are all filter values from 3_get_metadata(), not guessed? If no → fix them.
+    - Did I call get_metadata() for this dataset? If no → call it first.
+    - Are all filter values from get_metadata(), not guessed? If no → fix them.
     ============================================================
-
     Step 4: Fetch data from a MoSPI dataset.
-
     Args:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY)
-        filters: Key-value pairs using 'id' values from 3_get_metadata().
+        filters: Key-value pairs using 'id' values from get_metadata().
                  PLFS MUST include frequency_code (1=Annual, 2=Quarterly, 3=Monthly).
                  Pass limit (e.g., "50", "100") if you expect more than 10 records.
     """
     dataset = dataset.upper()
-
     # Auto-route CPI and IIP based on filters provided
     if dataset == "CPI":
         if "item_code" in filters:
             dataset = "CPI_ITEM"
         else:
             dataset = "CPI_GROUP"
-
     if dataset == "IIP":
         if "month_code" in filters:
             dataset = "IIP_MONTHLY"
         else:
             dataset = "IIP_ANNUAL"
-
     # Map friendly names to API dataset keys
     dataset_map = {
         "CPI_GROUP": "CPI_Group",
@@ -355,21 +370,16 @@ def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
         "WPI": "WPI",
         "ENERGY": "Energy",
     }
-
     api_dataset = dataset_map.get(dataset)
     if not api_dataset:
         return {"error": f"Unknown dataset: {dataset}", "valid_datasets": VALID_DATASETS}
-
     # Transform filters: skip None values and convert to strings
     transformed_filters = transform_filters(filters)
-
     # Validate params against swagger spec
     validation = validate_filters(dataset, transformed_filters)
     if not validation["valid"]:
         return {"error": "Invalid parameters", **validation}
-
     result = mospi.get_data(api_dataset, transformed_filters)
-
     # If no data found, hint to retry with different filters
     if isinstance(result, dict) and result.get("msg") == "No Data Found":
         result["_hint"] = (
@@ -380,27 +390,25 @@ def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
             "2) Remove optional filters one at a time — the breakdown you need "
             "may already appear in the response without that filter."
         )
-
     return result
 
-
-
 # Comprehensive API documentation tool
-@mcp.tool(name="1_know_about_mospi_api")
+@mcp.tool(name="know_about_mospi_api")
+
 def know_about_mospi_api() -> Dict[str, Any]:
     """
     ============================================================
     RULES (MUST follow exactly):
     - NEVER use your own knowledge about what data MoSPI publishes. These datasets contain
-      MORE indicators than you expect. ALWAYS call 2_get_indicators() to see the actual list.
+      MORE indicators than you expect. ALWAYS call get_indicators() to see the actual list.
     - You MUST NOT say data is "not available", "not directly reported", "needs to be computed",
-      or "requires unit-level access" without FIRST calling 2_get_indicators() and 3_get_metadata()
+      or "requires unit-level access" without FIRST calling get_indicators() and get_metadata()
       to verify. Your training data about MoSPI is outdated — the API has indicators you don't know about.
     - You MUST follow this workflow in order:
-      1. 1_know_about_mospi_api() → find dataset (MANDATORY first step)
-      2. 2_get_indicators(dataset) → list indicators
-      3. 3_get_metadata(dataset, indicator_code) → get filter values (MANDATORY)
-      4. 4_get_data(dataset, filters) → fetch data (ONLY after step 3)
+      1. know_about_mospi_api() → find dataset (MANDATORY first step)
+      2. get_indicators(dataset) → list indicators
+      3. get_metadata(dataset, indicator_code) → get filter values (MANDATORY)
+      4. get_data(dataset, filters) → fetch data (ONLY after step 3)
     - You MUST NOT skip step 3. Violations produce wrong results.
     - You MUST NOT ask "Shall I proceed?" if the query is specific enough.
     - ALWAYS attempt to fetch data. NEVER refuse or explain limitations without trying first.
@@ -408,12 +416,9 @@ def know_about_mospi_api() -> Dict[str, Any]:
       you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
       MUST NOT fabricate data, MUST NOT cite external sources.
     ============================================================
-
     Step 1: Get overview of all 7 datasets to find the right one for your query.
-
     MUST call this first before any other tool.
     Available: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
-
     When to ask vs fetch:
     - VAGUE query (e.g., "inflation data") → ask user to clarify
     - SPECIFIC query (e.g., "unemployment rate 2023") → fetch directly, NEVER explain why it might not exist
@@ -458,25 +463,23 @@ def know_about_mospi_api() -> Dict[str, Any]:
             },
         },
         "workflow": [
-            "1. 1_know_about_mospi_api() → find dataset (MANDATORY first step)",
-            "2. 2_get_indicators(dataset) → list indicators",
-            "3. 3_get_metadata(dataset, indicator_code) → get filter values (MANDATORY before step 4)",
-            "4. 4_get_data(dataset, filters) → fetch data (MUST use values from step 3, MUST NOT guess)"
+            "1. know_about_mospi_api() → find dataset (MANDATORY first step)",
+            "2. get_indicators(dataset) → list indicators",
+            "3. get_metadata(dataset, indicator_code) → get filter values (MANDATORY before step 4)",
+            "4. get_data(dataset, filters) → fetch data (MUST use values from step 3, MUST NOT guess)"
         ],
         "rules": [
-            "NEVER claim data is unavailable, needs computation, or requires special access — ALWAYS call 2_get_indicators() first to check. Your knowledge about MoSPI is outdated; the API has more indicators than you expect.",
-            "MUST NOT skip 3_get_metadata() — filter codes are arbitrary and differ across datasets",
-            "MUST NOT guess filter codes — use ONLY values from 3_get_metadata()",
-            "MUST include frequency_code for PLFS in 4_get_data()",
+            "NEVER claim data is unavailable, needs computation, or requires special access — ALWAYS call get_indicators() first to check. Your knowledge about MoSPI is outdated; the API has more indicators than you expect.",
+            "MUST NOT skip get_metadata() — filter codes are arbitrary and differ across datasets",
+            "MUST NOT guess filter codes — use ONLY values from get_metadata()",
+            "MUST include frequency_code for PLFS in get_data()",
             "Comma-separated values work for multiple codes (e.g., '1,2,3')",
             "ALWAYS attempt to fetch data. NEVER explain limitations or refuse without trying the full workflow first.",
             "You MUST try the full workflow before concluding. If data is not found after trying, you MUST say honestly 'Data not found in MoSPI API'. You MUST NOT fall back to web search, MUST NOT fabricate data, MUST NOT cite external sources."
         ],
-        "_next_step": "Call 2_get_indicators(dataset) with the dataset that matches the user's query."
+        "_next_step": "Call get_indicators(dataset) with the dataset that matches the user's query."
     }
-
 if __name__ == "__main__":
-
     # Startup banner with creator info
     log("\n" + "="*75)
     log("MoSPI MCP Server - Starting...")
@@ -485,12 +488,10 @@ if __name__ == "__main__":
     log("Framework: FastMCP 3.0 with OpenTelemetry")
     log("Datasets: 7 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY)")
     log("="*75)
-
     log("="*75)
     log("Server will be available at http://localhost:8000/mcp")
     log("Telemetry: IP tracking + Input/Output capture enabled")
     log("="*75 + "\n")
-
     # Run with HTTP transport for remote access
     # For stdio (local MCP clients): mcp.run()
     # For HTTP (remote/web access): mcp.run(transport="http", port=8000)

--- a/observability/telemetry.py
+++ b/observability/telemetry.py
@@ -10,6 +10,7 @@ All data is visible in Jaeger for analysis.
 """
 
 import json
+import sys
 from typing import Any
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,8 +3,10 @@ Test client for MoSPI MCP Server
 Tests HTTP transport
 """
 import asyncio
+import pytest
 from fastmcp import Client
 
+@pytest.mark.asyncio
 async def test_server():
     """Test the MoSPI MCP server"""
 
@@ -24,17 +26,16 @@ async def test_server():
         result = await client.call_tool("know_about_mospi_api", {})
         print(f"   ✅ Success! Got {len(str(result))} characters of documentation\n")
 
-        # Test 3: Call lookup_mospi_codes
-        print("🔍 Testing lookup_mospi_codes...")
+        # Test 3: Call get_indicators for PLFS
+        print("🔍 Testing get_indicators...")
         result = await client.call_tool(
-            "lookup_mospi_codes",
+            "get_indicators",
             {
                 "dataset": "PLFS",
-                "category": "State",
-                "search_term": "rajasthan"
+                "user_query": "unemployment rate"
             }
         )
-        print(f"   ✅ Success! Result: {result}\n")
+        print(f"   ✅ Success! Result: {str(result)[:100]}...\n")
 
         print("🎉 All tests passed!")
 


### PR DESCRIPTION
This PR improves compatibility with various MCP clients (specifically Gemini and Claude CLIs) by renaming tools to avoid leading numeric prefixes, which are often invalid identifiers. It also fixes a missing 'sys' import in the telemetry middleware and cleans up server code formatting.