### PR TITLE
feat: redesign from 4 tools to 2 (describe_dataset + get_data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ This server provides AI-ready access to official Indian government statistics th
 - Full OpenTelemetry integration for observability
 - Production-ready Docker deployment
 
-If you want to connect your AI agent of choice with the MCP server, you can directly connect it with MOSPI's MCP server. Instructions are available at https://www.datainnovation.mospi.gov.in/mospi-mcp. Instructions to connect ChatGPT or Claude to MCP are available here: https://www.datainnovation.mospi.gov.in/mospi-mcp
-
 ---
 
 ## Datasets
@@ -82,7 +80,13 @@ The server exposes 4 tools that follow a sequential workflow:
 
 ## Quick Start
 
-If you want to connect your AI agent of choice with the MCP server, you can directly connect it with MOSPI's MCP server. Instructions are available at https://www.datainnovation.mospi.gov.in/mospi-mcp. Instructions to connect ChatGPT or Claude to MCP are available here: https://www.datainnovation.mospi.gov.in/mospi-mcp
+If you want to connect your AI agent of choice with the MCP server, you can directly connect it with MOSPI's MCP server. Video Guides to connect ChatGPT or Claude to MCP are available here - 
+
+https://github.com/user-attachments/assets/ec23db03-c5ad-4bdd-af3a-9387bd906b3c
+
+https://github.com/user-attachments/assets/4d2adb2a-a350-4563-8408-c0790bb94412
+
+To get more information, visit - https://www.datainnovation.mospi.gov.in/mospi-mcp
 
 Below instructions are for self-hosting the MCP server. 
 

--- a/mospi/cache.py
+++ b/mospi/cache.py
@@ -1,0 +1,40 @@
+"""
+In-memory metadata cache for MoSPI API responses.
+TTL-based caching to avoid hitting the government API on every describe_dataset call.
+"""
+
+import time
+from typing import Any, Optional
+
+
+class MetadataCache:
+    """Simple in-memory cache with TTL expiry."""
+
+    def __init__(self, ttl_seconds: int = 3600):
+        self._cache: dict[str, Any] = {}
+        self._timestamps: dict[str, float] = {}
+        self._ttl = ttl_seconds
+
+    def get(self, key: str) -> Optional[Any]:
+        if key not in self._cache:
+            return None
+        if self._is_expired(key):
+            del self._cache[key]
+            del self._timestamps[key]
+            return None
+        return self._cache[key]
+
+    def set(self, key: str, value: Any) -> None:
+        self._cache[key] = value
+        self._timestamps[key] = time.time()
+
+    def _is_expired(self, key: str) -> bool:
+        return time.time() - self._timestamps.get(key, 0) > self._ttl
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._timestamps.clear()
+
+
+# Global cache instance
+metadata_cache = MetadataCache()

--- a/mospi/search.py
+++ b/mospi/search.py
@@ -1,0 +1,416 @@
+"""
+Search module for MoSPI metadata.
+Flattens all indicators and filter dimensions into a searchable list,
+performs case-insensitive substring matching, and returns matches with
+API param names and hierarchy context.
+"""
+
+import os
+import yaml
+import requests
+from typing import Any
+
+from mospi.cache import metadata_cache
+
+BASE_URL = "https://api.mospi.gov.in"
+SWAGGER_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "swagger")
+
+# Dataset descriptions for the response
+DATASET_DESCRIPTIONS = {
+    "PLFS": "Periodic Labour Force Survey — employment, unemployment, wages, workforce participation",
+    "CPI": "Consumer Price Index — retail inflation, cost of living, commodity prices",
+    "IIP": "Index of Industrial Production — manufacturing, mining, electricity output",
+    "ASI": "Annual Survey of Industries — factory financials, capital, wages, employment",
+    "NAS": "National Accounts Statistics — GDP, economic growth, national income",
+    "WPI": "Wholesale Price Index — wholesale/producer price inflation, commodity prices",
+    "ENERGY": "Energy Statistics — energy production, consumption, fuel mix",
+}
+
+# Required params per dataset from swagger specs
+# (param_name, swagger_file, endpoint_path)
+DATASET_SWAGGER = {
+    "PLFS": ("swagger_user_plfs.yaml", "/api/plfs/getData"),
+    "CPI": ("swagger_user_cpi.yaml", "/api/cpi/getCPIIndex"),
+    "IIP": ("swagger_user_iip.yaml", "/api/iip/getIIPAnnual"),
+    "ASI": ("swagger_user_asi.yaml", "/api/asi/getASIData"),
+    "NAS": ("swagger_user_nas.yaml", "/api/nas/getNASData"),
+    "WPI": ("swagger_user_wpi.yaml", "/api/wpi/getWpiRecords"),
+    "ENERGY": ("swagger_user_energy.yaml", "/api/energy/getEnergyRecords"),
+}
+
+# Hierarchical dimension mappings (parent -> child relationships)
+# Used to build context strings for search results
+HIERARCHY_MAPS = {
+    "WPI": {
+        "dimensions": ["major_group", "group", "sub_group", "sub_sub_group", "item"],
+        "code_keys": ["major_group_code", "group_code", "sub_group_code", "sub_sub_group_code", "item_code"],
+        "name_keys": ["major_group_name", "group_name", "sub_group_name", "sub_sub_group_name", "item_name"],
+    },
+    "ASI": {
+        "dimensions": ["nic_2_digit", "nic_3_digit", "nic_4_digit"],
+        "code_keys": ["nic_code", "nic_code", "nic_code"],
+        "name_keys": ["nic_name", "nic_name", "nic_name"],
+        "parent_key": "parent_nic_code",
+    },
+    "IIP": {
+        "dimensions": ["category", "subcategory"],
+        "code_keys": ["category_code", "subcategory_code"],
+        "name_keys": ["category_name", "subcategory_name"],
+    },
+    "CPI": {
+        "dimensions": ["group", "subgroup"],
+        "code_keys": ["group_code", "subgroup_code"],
+        "name_keys": ["group_name", "subgroup_name"],
+    },
+    "NAS": {
+        "dimensions": ["industry", "subindustry"],
+        "code_keys": ["industry_code", "subindustry_code"],
+        "name_keys": ["industry_name", "subindustry_name"],
+    },
+}
+
+
+def _fetch_json(url: str, params: dict = None) -> dict:
+    """Fetch JSON from a URL with caching."""
+    cache_key = f"{url}:{params}"
+    cached = metadata_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        response = requests.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        metadata_cache.set(cache_key, data)
+        return data
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _get_required_params(dataset: str) -> list[dict]:
+    """Get required params from swagger spec for a dataset."""
+    if dataset not in DATASET_SWAGGER:
+        return []
+    yaml_file, endpoint_path = DATASET_SWAGGER[dataset]
+    swagger_path = os.path.join(SWAGGER_DIR, yaml_file)
+    if not os.path.exists(swagger_path):
+        return []
+    with open(swagger_path, "r") as f:
+        spec = yaml.safe_load(f)
+    params = spec.get("paths", {}).get(endpoint_path, {}).get("get", {}).get("parameters", [])
+    return [p for p in params if p.get("required") and p["name"] != "Format"]
+
+
+def _load_all_metadata(dataset: str) -> list[dict]:
+    """
+    Load all indicators and filter values for a dataset.
+    Returns a flat list of searchable entries:
+    [{"param": "indicator_code", "code": 3, "name": "Unemployment Rate", "context": ""}, ...]
+    """
+    entries = []
+    dataset = dataset.upper()
+
+    if dataset == "PLFS":
+        # Indicators (fetch all frequency codes)
+        for fc in [1, 2, 3]:
+            freq_label = {1: "Annual", 2: "Quarterly", 3: "Monthly"}[fc]
+            data = _fetch_json(f"{BASE_URL}/api/plfs/getIndicatorListByFrequency", {"frequency_code": fc})
+            for ind in data.get("data", []):
+                entries.append({
+                    "param": "indicator_code",
+                    "code": ind["indicator_code"],
+                    "name": ind["description"],
+                    "context": f"frequency_code={fc} ({freq_label})",
+                })
+
+        # Filters (use indicator_code=3 as representative — filters are same across indicators)
+        data = _fetch_json(f"{BASE_URL}/api/plfs/getFilterByIndicatorId", {"indicator_code": 3, "frequency_code": 1})
+        filters = data.get("data", {})
+        for dim_name, values in filters.items():
+            if not isinstance(values, list):
+                continue
+            for item in values:
+                code_key = next((k for k in item.keys() if k.endswith("_code") or k == "year"), None)
+                name_key = next((k for k in item.keys() if k in ("description", "name") or k == "year"), None)
+                if code_key:
+                    param_name = code_key if code_key != "year" else "year"
+                    entries.append({
+                        "param": param_name,
+                        "code": item[code_key],
+                        "name": item.get(name_key, str(item[code_key])) if name_key else str(item[code_key]),
+                    })
+
+        # Add frequency_code options
+        for fc, label in [(1, "Annual"), (2, "Quarterly"), (3, "Monthly")]:
+            entries.append({"param": "frequency_code", "code": fc, "name": label})
+
+    elif dataset == "CPI":
+        data = _fetch_json(f"{BASE_URL}/api/cpi/getCpiFilterByLevelAndBaseYear", {"base_year": "2012", "level": "Group"})
+        filters = data.get("data", {})
+
+        # Add base_year and level options (not in filter response)
+        for by in ["2012", "2010"]:
+            entries.append({"param": "base_year", "code": by, "name": f"Base Year {by}"})
+        for lvl in ["Group", "Item"]:
+            entries.append({"param": "level", "code": lvl, "name": f"Level: {lvl}"})
+
+        _flatten_filters(entries, filters, dataset)
+
+    elif dataset == "IIP":
+        data = _fetch_json(f"{BASE_URL}/api/iip/getIipFilter", {"base_year": "2011-12", "frequency": "Annually"})
+        filters = data.get("data", {})
+
+        # Add base_year and frequency options
+        for by in ["2011-12", "2004-05", "1993-94"]:
+            entries.append({"param": "base_year", "code": by, "name": f"Base Year {by}"})
+        for freq in ["Annually", "Monthly"]:
+            entries.append({"param": "frequency", "code": freq, "name": freq})
+
+        _flatten_filters(entries, filters, dataset)
+
+    elif dataset == "ASI":
+        data = _fetch_json(f"{BASE_URL}/api/asi/getAsiFilter", {"classification_year": "2008"})
+        filters = data.get("data", {})
+
+        # Add classification_year options
+        for cy in ["2008", "2004", "1998", "1987"]:
+            entries.append({"param": "classification_year", "code": cy, "name": f"NIC Classification {cy}"})
+
+        _flatten_filters(entries, filters, dataset)
+
+    elif dataset == "NAS":
+        # Indicators
+        data = _fetch_json(f"{BASE_URL}/api/nas/getNasIndicatorList")
+        ind_data = data.get("data", {})
+
+        # Series options
+        for s in ind_data.get("series", []):
+            entries.append({"param": "series", "code": s["series"], "name": f"Series: {s['series']}"})
+
+        # Frequency options
+        for f_item in ind_data.get("frequency", []):
+            entries.append({
+                "param": "frequency_code",
+                "code": f_item["frequency_code"],
+                "name": f_item["description"],
+                "context": f"series: {f_item.get('series', '')}",
+            })
+
+        # Annual indicators
+        for ind in ind_data.get("indicator", []):
+            entries.append({
+                "param": "indicator_code",
+                "code": ind["indicator_code"],
+                "name": ind["description"],
+                "context": "Annual",
+            })
+
+        # Quarterly indicators
+        for ind in ind_data.get("quarter_indicator", []):
+            entries.append({
+                "param": "indicator_code",
+                "code": ind["indicator_code"],
+                "name": ind["description"],
+                "context": "Quarterly",
+            })
+
+        # Filters
+        filters_data = _fetch_json(f"{BASE_URL}/api/nas/getNasFilterByIndicatorId",
+                                   {"series": "Current", "frequency_code": 1, "indicator_code": 1})
+        _flatten_filters(entries, filters_data.get("data", {}), dataset)
+
+    elif dataset == "WPI":
+        data = _fetch_json(f"{BASE_URL}/api/wpi/getWpiData")
+        _flatten_filters(entries, data.get("data", {}), dataset)
+
+    elif dataset == "ENERGY":
+        # Indicators
+        data = _fetch_json(f"{BASE_URL}/api/energy/getEnergyIndicatorList")
+        ind_data = data.get("data", {})
+
+        for ind in ind_data.get("indicator", []):
+            entries.append({
+                "param": "indicator_code",
+                "code": ind["indicator_code"],
+                "name": ind["description"],
+            })
+
+        for balance in ind_data.get("use_of_energy_balance", []):
+            entries.append({
+                "param": "use_of_energy_balance_code",
+                "code": balance["use_of_energy_balance_code"],
+                "name": balance["use_of_energy_balance_name"],
+            })
+
+        # Filters — load all indicator × balance combinations so sub-commodities
+        # and sectors are searchable regardless of which combo the query needs.
+        # Merge filter dicts to deduplicate entries that appear in multiple combos.
+        merged_filters = {}
+        for ind_code in [ind["indicator_code"] for ind in ind_data.get("indicator", [])]:
+            for bal_code in [b["use_of_energy_balance_code"] for b in ind_data.get("use_of_energy_balance", [])]:
+                filters_data = _fetch_json(f"{BASE_URL}/api/energy/getEnergyFilterByIndicatorId",
+                                           {"indicator_code": ind_code, "use_of_energy_balance_code": bal_code})
+                for dim_name, values in filters_data.get("data", {}).items():
+                    if not isinstance(values, list):
+                        continue
+                    existing = {str(v): v for v in merged_filters.get(dim_name, [])}
+                    for item in values:
+                        key = str(item)
+                        if key not in existing:
+                            existing[key] = item
+                    merged_filters[dim_name] = list(existing.values())
+        _flatten_filters(entries, merged_filters, dataset)
+
+    return entries
+
+
+def _flatten_filters(entries: list, filters: dict, dataset: str) -> None:
+    """Flatten filter dimension values into searchable entries."""
+    hierarchy = HIERARCHY_MAPS.get(dataset)
+
+    # Build parent lookup for hierarchical dimensions
+    parent_lookup = {}
+    if hierarchy:
+        for dim_name in hierarchy["dimensions"]:
+            values = filters.get(dim_name, [])
+            for item in values:
+                code_key = next((k for k in item.keys() if k.endswith("_code")), None)
+                name_key = next((k for k in item.keys() if k.endswith("_name")), None)
+                if code_key:
+                    parent_lookup[str(item[code_key])] = item.get(name_key, "")
+
+    for dim_name, values in filters.items():
+        if not isinstance(values, list):
+            continue
+
+        for item in values:
+            # Find the code and name keys
+            code_key = next((k for k in item.keys() if k.endswith("_code") or k == "year"), None)
+            name_key = next((k for k in item.keys()
+                            if k.endswith("_name") or k == "description" or k == "year"
+                            ), None)
+
+            if code_key is None:
+                # Handle simple entries like {"year": "2017-18"}, {"series": "Current"}
+                for k, v in item.items():
+                    if k not in ("viz",):
+                        entries.append({"param": k, "code": v, "name": str(v)})
+                continue
+
+            param_name = code_key
+            code_val = item[code_key]
+            name_val = str(item.get(name_key, code_val)) if name_key else str(code_val)
+
+            entry = {"param": param_name, "code": code_val, "name": name_val}
+
+            # Add hierarchy context if applicable
+            if hierarchy and dim_name in hierarchy["dimensions"]:
+                # Add dimension level (e.g., "2-digit" from "nic_2_digit")
+                level_label = dim_name  # default
+                for part in dim_name.split("_"):
+                    if "digit" in part or part.isdigit():
+                        level_label = dim_name.replace("_", " ")
+                        break
+
+                parent_code_key = hierarchy.get("parent_key")
+                if parent_code_key and parent_code_key in item:
+                    parent_code = str(item[parent_code_key])
+                    parent_name = parent_lookup.get(parent_code, parent_code)
+                    entry["context"] = f"{level_label}, parent: {parent_name}"
+                elif "parent_nic_code" in item:
+                    parent_code = str(item["parent_nic_code"])
+                    parent_name = parent_lookup.get(parent_code, parent_code)
+                    entry["context"] = f"{level_label}, parent: {parent_name}"
+                elif dim_name in ("subgroup", "subcategory", "subindustry"):
+                    for pk in item.keys():
+                        if pk.endswith("_code") and pk != code_key:
+                            parent_code = str(item[pk])
+                            parent_name = parent_lookup.get(parent_code, parent_code)
+                            entry["context"] = f"{dim_name}, parent: {parent_name}"
+                            break
+                else:
+                    # Top-level dimension (no parent) — still label it
+                    entry["context"] = f"{level_label} (top-level)"
+
+            entries.append(entry)
+
+
+def search_dataset(dataset: str, search_terms: list[str]) -> dict[str, Any]:
+    """
+    Search a dataset's metadata for matching indicators and filter values.
+
+    Returns:
+        {
+            "dataset": "PLFS",
+            "description": "...",
+            "matches": [{"param": "indicator_code", "code": 3, "name": "...", "context": "..."}],
+            "unmatched_required_params": {"frequency_code": {"description": "...", "options": [...]}}
+        }
+    """
+    dataset = dataset.upper()
+
+    if dataset not in DATASET_DESCRIPTIONS:
+        return {
+            "error": f"Unknown dataset: {dataset}",
+            "valid_datasets": list(DATASET_DESCRIPTIONS.keys()),
+        }
+
+    # Load all metadata entries
+    all_entries = _load_all_metadata(dataset)
+
+    if not all_entries:
+        return {
+            "dataset": dataset,
+            "description": DATASET_DESCRIPTIONS[dataset],
+            "matches": [],
+            "error": "Could not load metadata for this dataset",
+        }
+
+    # Search: case-insensitive substring match, OR across terms
+    matches = []
+    matched_params = set()
+
+    for entry in all_entries:
+        searchable = str(entry["name"]).lower()
+        context_str = str(entry.get("context", "")).lower()
+        for term in search_terms:
+            term_lower = term.lower()
+            if term_lower in searchable or term_lower in context_str or term_lower in str(entry["code"]).lower():
+                matches.append(entry)
+                matched_params.add(entry["param"])
+                break  # Don't double-add if multiple terms match same entry
+
+    # Determine unmatched required params
+    required_params = _get_required_params(dataset)
+    unmatched_required = {}
+
+    for param_def in required_params:
+        param_name = param_def["name"]
+        if param_name not in matched_params:
+            # Find all options for this param from the full entries list
+            options = [
+                {"code": e["code"], "name": e["name"]}
+                for e in all_entries
+                if e["param"] == param_name
+            ]
+            # Dedupe
+            seen = set()
+            unique_options = []
+            for opt in options:
+                key = (str(opt["code"]), opt["name"])
+                if key not in seen:
+                    seen.add(key)
+                    unique_options.append(opt)
+
+            if unique_options:
+                unmatched_required[param_name] = {
+                    "description": param_def.get("description", param_name),
+                    "options": unique_options,
+                }
+
+    return {
+        "dataset": dataset,
+        "description": DATASET_DESCRIPTIONS[dataset],
+        "matches": matches,
+        "unmatched_required_params": unmatched_required if unmatched_required else None,
+    }

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -1,9 +1,10 @@
 import sys
 import os
 import yaml
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List
 from fastmcp import FastMCP
 from mospi.client import mospi
+from mospi.search import search_dataset
 from observability.telemetry import TelemetryMiddleware
 
 SWAGGER_DIR = os.path.join(os.path.dirname(__file__), "swagger")
@@ -25,7 +26,6 @@ VALID_DATASETS = [
 ]
 
 # Maps dataset key -> (swagger_yaml_file, endpoint_path)
-# Swagger YAMLs are the single source of truth for valid API parameters.
 DATASET_SWAGGER = {
     "PLFS": ("swagger_user_plfs.yaml", "/api/plfs/getData"),
     "CPI": ("swagger_user_cpi.yaml", "/api/cpi/getCPIIndex"),
@@ -39,11 +39,6 @@ DATASET_SWAGGER = {
     "WPI": ("swagger_user_wpi.yaml", "/api/wpi/getWpiRecords"),
     "ENERGY": ("swagger_user_energy.yaml", "/api/energy/getEnergyRecords"),
 }
-
-# Datasets that require indicator_code in get_data
-DATASETS_REQUIRING_INDICATOR = [
-    "PLFS", "NAS", "ENERGY",
-]
 
 
 def get_swagger_param_definitions(dataset: str) -> list:
@@ -60,11 +55,6 @@ def get_swagger_param_definitions(dataset: str) -> list:
     return spec.get("paths", {}).get(endpoint_path, {}).get("get", {}).get("parameters", [])
 
 
-def get_swagger_params(dataset: str) -> list:
-    """Get list of valid param names for a dataset from swagger."""
-    return [p["name"] for p in get_swagger_param_definitions(dataset)]
-
-
 def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
     """
     Validate filters against swagger spec for a dataset.
@@ -72,7 +62,7 @@ def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
     """
     param_defs = get_swagger_param_definitions(dataset)
     if not param_defs:
-        return {"valid": True}  # Can't validate, pass through
+        return {"valid": True}
 
     valid_params = [p["name"] for p in param_defs]
 
@@ -83,7 +73,7 @@ def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
             "valid": False,
             "invalid_params": invalid,
             "valid_params": valid_params,
-            "hint": f"Invalid params: {invalid}. Check api_params from 3_get_metadata for valid options."
+            "hint": f"Invalid params: {invalid}. Use describe_dataset() to find valid param names."
         }
 
     # Check for missing required params (exclude Format — auto-handled by client)
@@ -95,238 +85,49 @@ def validate_filters(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
         return {
             "valid": False,
             "missing_required": missing,
-            "hint": f"Missing required params: {missing}. Call 3_get_metadata() to get valid values."
+            "hint": f"Missing required params: {missing}. Use describe_dataset() to find valid values."
         }
 
     return {"valid": True}
 
 
 def transform_filters(filters: Dict[str, str]) -> Dict[str, str]:
-    """
-    Transform filters: skip None values and convert all values to strings.
-    """
+    """Transform filters: skip None values and convert all values to strings."""
     return {k: str(v) for k, v in filters.items() if v is not None}
 
 
-@mcp.tool(name="2_get_indicators")
-def get_indicators(
-    dataset: str,
-    user_query: Optional[str] = None,
-    classification_year: Optional[str] = None,
-    base_year: Optional[str] = None,
-    frequency: Optional[str] = None,
-    frequency_code: Optional[int] = None,
-    level: Optional[str] = None,
-    series: Optional[str] = None,
-    Format: Optional[str] = None
-) -> Dict[str, Any]:
+# =============================================================================
+# Tool 1: describe_dataset — search metadata for indicators and filter values
+# =============================================================================
+
+@mcp.tool(name="describe_dataset")
+def describe_dataset(dataset: str, search_terms: List[str]) -> Dict[str, Any]:
     """
-    ============================================================
-    RULES (MUST follow exactly):
-    - You MUST call 1_know_about_mospi_api() before this.
-    - You MUST call 3_get_metadata() after this. MUST NOT skip to 4_get_data().
-    - You MUST pass user_query for context.
-    - You MUST NOT ask for confirmation if the right indicator is obvious.
-    - ALWAYS call this tool. NEVER assume data is unavailable based on your own knowledge.
-      The API has indicators you don't know about (e.g., ASI has 57 indicators including
-      working capital, invested capital, depreciation — not just the ones in textbooks).
-    - You MUST try the full workflow before concluding. If data is not found after trying,
-      you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
-      MUST NOT fabricate data, MUST NOT cite external sources.
-    ============================================================
+    Search a MoSPI dataset for indicators and filter values.
 
-    Step 2: Get available indicators for a dataset.
+    Datasets: PLFS (employment), CPI (inflation), IIP (industrial production),
+    ASI (factory data), NAS (GDP), WPI (wholesale prices), ENERGY.
 
-    IMPORTANT: Datasets contain FAR MORE indicators than you expect from your training data.
-    ALWAYS call this to see the actual indicator list. NEVER say "not available" without checking.
+    search_terms: case-insensitive search across all indicators and filters.
+    Be liberal — include synonyms, abbreviations, and related terms.
+    e.g., for "unemployment in Maharashtra":
+      search_terms=["unemployment", "UR", "maharashtra", "2022", "2023"]
 
-    After this, pick the matching indicator and call 3_get_metadata().
-    Only ask user to choose if multiple indicators could match.
-
-    Args:
-        dataset: Dataset name - one of: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
-                 For PLFS: frequency_code selects the indicator SET, not time granularity.
-                 You MUST use frequency_code=1 in 3_get_metadata() — it covers all 8 indicators
-                 including wages and already has quarterly breakdowns via quarter_code.
-                 MUST NOT use frequency_code=2 just because user asks for quarterly data.
-        user_query: The user's original question. MUST always include this.
+    Returns matching codes to use in get_data(), plus any required params
+    you didn't search for with their full option lists.
     """
-    dataset = dataset.upper()
-
-    indicator_methods = {
-        "PLFS": mospi.get_plfs_indicators,
-        "NAS": mospi.get_nas_indicators,
-        "ENERGY": mospi.get_energy_indicators,
-        # Special datasets - return guidance instead of indicators
-        "CPI": lambda: {"message": "CPI uses levels (Group/Item) instead of indicators. Call 3_get_metadata with base_year and level params.", "dataset": "CPI"},
-        "IIP": lambda: {"message": "IIP uses categories instead of indicators. Call 3_get_metadata with base_year and frequency params.", "dataset": "IIP"},
-        "WPI": lambda: {"message": "WPI uses hierarchical commodity codes. Call 3_get_metadata to see available groups/items.", "dataset": "WPI"},
-        "ASI": mospi.get_asi_indicators,
-    }
-
-    if dataset not in indicator_methods:
-        return {"error": f"Unknown dataset: {dataset}", "valid_datasets": VALID_DATASETS, "_user_query": user_query}
-
-    result = indicator_methods[dataset]()
-    result["_user_query"] = user_query
-    result["_next_step"] = "Call 3_get_metadata() with the matching indicator and required dataset params. MUST NOT skip to 4_get_data."
-    result["_retry_hint"] = (
-        "If none of the indicators above match the user's query, you may have picked the WRONG dataset. "
-        "Similar datasets overlap: IIP (production index/growth rates) vs ASI (factory financials like capital, wages, GVA). "
-        "CPI (consumer inflation) vs WPI (wholesale inflation). "
-        "Go back to 1_know_about_mospi_api() and try a different dataset."
-    )
-    return result
+    return search_dataset(dataset, search_terms)
 
 
-@mcp.tool(name="3_get_metadata")
-def get_metadata(
-    dataset: str,
-    indicator_code: Optional[int] = None,
-    base_year: Optional[str] = None,
-    level: Optional[str] = None,
-    frequency: Optional[str] = None,
-    classification_year: Optional[str] = None,
-    frequency_code: Optional[int] = None,
-    series: Optional[str] = None,
-    use_of_energy_balance_code: Optional[int] = None,
-    sub_indicator_code: Optional[int] = None,
-    Format: Optional[str] = None,
-    type: Optional[str] = None
-) -> Dict[str, Any]:
-    """
-    ============================================================
-    RULES (MUST follow exactly):
-    - You MUST call this before 4_get_data(). MUST NOT skip this step.
-    - You MUST use the filter values returned here in 4_get_data(). MUST NOT guess codes.
-    - If user asked for a breakdown that's not available, tell them what IS available.
-    - You MUST try the full workflow before concluding. If data is not found after trying,
-      you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
-      MUST NOT fabricate data, MUST NOT cite external sources.
-    ============================================================
+# =============================================================================
+# Tool 2: get_data — fetch data using codes from describe_dataset
+# =============================================================================
 
-    Step 3: Get available filter options for a dataset/indicator.
-
-    Returns all valid filter values (states, years, quarters, etc.) to use in 4_get_data().
-
-    MUST NOT pass params that don't belong to this function.
-    "Format" and "series" are NOT valid here (Format is for 4_get_data only, series is for NAS only).
-
-    Args:
-        dataset: Dataset name - one of: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
-        indicator_code: REQUIRED for PLFS, NAS, ENERGY. MUST NOT pass for CPI, IIP, ASI, WPI.
-        frequency_code: REQUIRED for PLFS. MUST NOT pass for CPI, IIP, ASI, WPI.
-                        Selects indicator SET, NOT time granularity.
-                        1=Annual (all 8 indicators, includes quarterly data via quarter_code).
-                        2=Quarterly bulletin (different indicator set).
-                        3=Monthly bulletin (2025+ only).
-                        MUST NOT use 2 for quarterly data. Use 1 + quarter_code in 4_get_data().
-        base_year: REQUIRED for CPI ("2012"/"2010"), IIP ("2011-12"/"2004-05"/"1993-94"). MUST NOT pass for PLFS, ASI, WPI.
-        level: REQUIRED for CPI ("Group"/"Item"). MUST NOT pass for other datasets.
-        frequency: REQUIRED for IIP ("Annually"/"Monthly"). MUST NOT pass for other datasets.
-        classification_year: REQUIRED for ASI ("2008"/"2004"/"1998"/"1987"). MUST NOT pass for other datasets.
-        series: For NAS only ("Current"/"Back"). MUST NOT pass for other datasets.
-        use_of_energy_balance_code: For ENERGY only (1=Supply, 2=Consumption). MUST NOT pass for other datasets.
-    """
-    dataset = dataset.upper()
-
-    try:
-        _next = "Call 4_get_data(dataset, filters) using ONLY the filter values returned above. MUST NOT guess any codes."
-
-        if dataset == "CPI":
-            swagger_key = "CPI_ITEM" if (level or "Group") == "Item" else "CPI_GROUP"
-            result = mospi.get_cpi_filters(base_year=base_year or "2012", level=level or "Group")
-            result["api_params"] = get_swagger_param_definitions(swagger_key)
-            result["_next_step"] = _next
-            return result
-
-        elif dataset == "IIP":
-            swagger_key = "IIP_MONTHLY" if (frequency or "Annually") == "Monthly" else "IIP_ANNUAL"
-            result = mospi.get_iip_filters(base_year=base_year or "2011-12", frequency=frequency or "Annually")
-            result["api_params"] = get_swagger_param_definitions(swagger_key)
-            result["_next_step"] = _next
-            return result
-
-        elif dataset == "ASI":
-            result = mospi.get_asi_filters(classification_year=classification_year or "2008")
-            result["api_params"] = get_swagger_param_definitions("ASI")
-            result["_next_step"] = _next
-            return result
-
-        elif dataset == "WPI":
-            result = mospi.get_wpi_filters()
-            result["api_params"] = get_swagger_param_definitions("WPI")
-            result["_next_step"] = _next
-            return result
-
-        elif dataset == "PLFS":
-            if indicator_code is None:
-                return {"error": "indicator_code is required for PLFS"}
-
-            filters = mospi.get_plfs_filters(indicator_code=indicator_code, frequency_code=frequency_code or 1)
-
-            return {
-                "dataset": "PLFS",
-                "filter_values": filters,
-                "api_params": get_swagger_param_definitions("PLFS"),
-                "_note": "frequency_code selects the indicator SET, NOT time granularity. "
-                         "frequency_code=1 (Annual): Indicators 1-8 (LFPR, WPR, UR, wages, worker distribution, employment conditions). "
-                         "Already has quarterly breakdowns — use quarter_code to filter by quarter. "
-                         "frequency_code=2 (Quarterly bulletin): Different indicators for quarterly bulletin tables only. "
-                         "Use ONLY when the user explicitly asks for quarterly bulletin specific data. "
-                         "MUST pass the correct frequency_code in 4_get_data().",
-                "_next_step": _next,
-            }
-
-        elif dataset == "NAS":
-            if indicator_code is None:
-                return {"error": "indicator_code is required for NAS"}
-            result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code)
-            result["api_params"] = get_swagger_param_definitions("NAS")
-            result["_next_step"] = _next
-            return result
-
-        elif dataset == "ENERGY":
-            ind_code = indicator_code or 1
-            energy_code = use_of_energy_balance_code or 1
-            result = mospi.get_energy_filters(indicator_code=ind_code, use_of_energy_balance_code=energy_code)
-            result["api_params"] = get_swagger_param_definitions("ENERGY")
-            result["_next_step"] = _next
-            return result
-
-        else:
-            return {"error": f"Unknown dataset: {dataset}", "valid_datasets": VALID_DATASETS}
-
-    except Exception as e:
-        return {"error": str(e)}
-
-
-@mcp.tool(name="4_get_data")
+@mcp.tool(name="get_data")
 def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
     """
-    ============================================================
-    RULES (MUST follow exactly):
-    - You MUST have called 3_get_metadata() before this. No exceptions.
-    - You MUST use ONLY the filter values returned by 3_get_metadata().
-    - You MUST NOT guess, infer, or assume any filter codes.
-      Filter codes are non-obvious and arbitrary — guessing WILL produce wrong results.
-    - You MUST include all required params (marked required in api_params).
-    - You MUST try the full workflow before concluding. If data is not found after trying,
-      you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
-      MUST NOT fabricate data, MUST NOT cite external sources.
-
-    Before calling, verify:
-    - Did I call 3_get_metadata() for this dataset? If no → call it first.
-    - Are all filter values from 3_get_metadata(), not guessed? If no → fix them.
-    ============================================================
-
-    Step 4: Fetch data from a MoSPI dataset.
-
-    Args:
-        dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY)
-        filters: Key-value pairs using 'id' values from 3_get_metadata().
-                 PLFS MUST include frequency_code (1=Annual, 2=Quarterly, 3=Monthly).
-                 Pass limit (e.g., "50", "100") if you expect more than 10 records.
+    Fetch data from a MoSPI dataset. Use codes from describe_dataset().
+    Pass limit (e.g., "50", "100") if you expect many records.
     """
     dataset = dataset.upper()
 
@@ -343,7 +144,7 @@ def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
         else:
             dataset = "IIP_ANNUAL"
 
-    # Map friendly names to API dataset keys
+    # Map to API dataset keys
     dataset_map = {
         "CPI_GROUP": "CPI_Group",
         "CPI_ITEM": "CPI_Item",
@@ -370,128 +171,28 @@ def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
 
     result = mospi.get_data(api_dataset, transformed_filters)
 
-    # If no data found, hint to retry with different filters
+    # If no data found, provide guidance
     if isinstance(result, dict) and result.get("msg") == "No Data Found":
-        result["_hint"] = (
-            "No data for this filter combination. Try these fixes: "
-            "1) Some filters represent the same concept under different params "
-            "(e.g., tertiary sector may be broad_industry_work_code OR nic_group_code) — "
-            "swap to the alternative param. "
-            "2) Remove optional filters one at a time — the breakdown you need "
-            "may already appear in the response without that filter."
+        result["hint"] = (
+            "No data for this filter combination. Try: "
+            "1) Remove optional filters one at a time. "
+            "2) Use describe_dataset() to verify your codes are correct. "
+            "3) Try a broader filter (e.g., group level instead of item level)."
         )
 
     return result
 
 
-
-# Comprehensive API documentation tool
-@mcp.tool(name="1_know_about_mospi_api")
-def know_about_mospi_api() -> Dict[str, Any]:
-    """
-    ============================================================
-    RULES (MUST follow exactly):
-    - NEVER use your own knowledge about what data MoSPI publishes. These datasets contain
-      MORE indicators than you expect. ALWAYS call 2_get_indicators() to see the actual list.
-    - You MUST NOT say data is "not available", "not directly reported", "needs to be computed",
-      or "requires unit-level access" without FIRST calling 2_get_indicators() and 3_get_metadata()
-      to verify. Your training data about MoSPI is outdated — the API has indicators you don't know about.
-    - You MUST follow this workflow in order:
-      1. 1_know_about_mospi_api() → find dataset (MANDATORY first step)
-      2. 2_get_indicators(dataset) → list indicators
-      3. 3_get_metadata(dataset, indicator_code) → get filter values (MANDATORY)
-      4. 4_get_data(dataset, filters) → fetch data (ONLY after step 3)
-    - You MUST NOT skip step 3. Violations produce wrong results.
-    - You MUST NOT ask "Shall I proceed?" if the query is specific enough.
-    - ALWAYS attempt to fetch data. NEVER refuse or explain limitations without trying first.
-    - You MUST try the full workflow before concluding. If data is not found after trying,
-      you MUST say honestly "Data not found in MoSPI API". You MUST NOT fall back to web search,
-      MUST NOT fabricate data, MUST NOT cite external sources.
-    ============================================================
-
-    Step 1: Get overview of all 7 datasets to find the right one for your query.
-
-    MUST call this first before any other tool.
-    Available: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
-
-    When to ask vs fetch:
-    - VAGUE query (e.g., "inflation data") → ask user to clarify
-    - SPECIFIC query (e.g., "unemployment rate 2023") → fetch directly, NEVER explain why it might not exist
-    """
-    return {
-        "total_datasets": 7,
-        "datasets": {
-            "PLFS": {
-                "name": "Periodic Labour Force Survey",
-                "description": "8 indicators covering labor market dynamics: Labour Force Participation Rate (LFPR), Worker Population Ratio (WPR), Unemployment Rate (UR), worker distribution by sector/industry, employment conditions for regular wage employees, and earnings data across three employment types—regular wages, casual labor, and self-employment.",
-                "use_for": "Jobs, unemployment, wages, workforce participation, employment conditions"
-            },
-            "CPI": {
-                "name": "Consumer Price Index",
-                "description": "Hierarchical commodity structure (Groups and Items) with base years 2010/2012. Tracks consumer inflation across 600+ items organized into food, fuel, housing, clothing, and miscellaneous categories. Supports state-level analysis at group level and All-India analysis at item level.",
-                "use_for": "Retail inflation, price indices, cost of living, commodity price trends"
-            },
-            "IIP": {
-                "name": "Index of Industrial Production",
-                "description": "Category-based structure with base years (1993-94, 2004-05, 2011-12) and frequency options (monthly/annual). Measures industrial output across manufacturing, mining, and electricity sectors using use-based classification (basic goods, capital goods, intermediate goods, consumer durables/non-durables).",
-                "use_for": "IIP index, industrial production index, manufacturing index, mining/electricity index, growth rates, textiles, metals, vehicles, consumer durables, capital goods — use for ANY query about IIP or industrial production index"
-            },
-            "ASI": {
-                "name": "Annual Survey of Industries",
-                "description": "57 indicators providing deep factory-sector analytics: capital structure (fixed/working capital, investments), production metrics (output, inputs, value added), employment details (workers by gender, contract status, mandays), wage components (salaries, bonuses, employer contributions), fuel consumption patterns, and profitability measures. Uses NIC classification across 4 classification years (1987-2008).",
-                "use_for": "Factory-level financials: working capital, fixed capital, wages, employment counts, GVA, fuel consumption, profitability — NOT for production index (use IIP for index)"
-            },
-            "NAS": {
-                "name": "National Accounts Statistics",
-                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. Both Current and Back series available.",
-                "use_for": "GDP, economic growth, national income, sectoral contribution, macro analysis"
-            },
-            "WPI": {
-                "name": "Wholesale Price Index",
-                "description": "Hierarchical commodity structure with 1000+ items across 5 levels: Major Groups (Primary articles, Fuel & power, Manufactured products, Food index) → Groups (22) → Sub-groups (90+) → Sub-sub-groups → Items. Tracks wholesale/producer price inflation monthly.",
-                "use_for": "Wholesale inflation, producer prices, commodity price trends"
-            },
-            "ENERGY": {
-                "name": "Energy Statistics",
-                "description": "2 indicators (KToE and PetaJoules) measuring energy balance across supply and consumption dimensions. Covers all energy commodities (coal, oil, gas, renewables, electricity) and tracks energy flows through production, transformation, and end-use sectors.",
-                "use_for": "Energy production, consumption patterns, fuel mix, sectoral energy use, climate analysis"
-            },
-        },
-        "workflow": [
-            "1. 1_know_about_mospi_api() → find dataset (MANDATORY first step)",
-            "2. 2_get_indicators(dataset) → list indicators",
-            "3. 3_get_metadata(dataset, indicator_code) → get filter values (MANDATORY before step 4)",
-            "4. 4_get_data(dataset, filters) → fetch data (MUST use values from step 3, MUST NOT guess)"
-        ],
-        "rules": [
-            "NEVER claim data is unavailable, needs computation, or requires special access — ALWAYS call 2_get_indicators() first to check. Your knowledge about MoSPI is outdated; the API has more indicators than you expect.",
-            "MUST NOT skip 3_get_metadata() — filter codes are arbitrary and differ across datasets",
-            "MUST NOT guess filter codes — use ONLY values from 3_get_metadata()",
-            "MUST include frequency_code for PLFS in 4_get_data()",
-            "Comma-separated values work for multiple codes (e.g., '1,2,3')",
-            "ALWAYS attempt to fetch data. NEVER explain limitations or refuse without trying the full workflow first.",
-            "You MUST try the full workflow before concluding. If data is not found after trying, you MUST say honestly 'Data not found in MoSPI API'. You MUST NOT fall back to web search, MUST NOT fabricate data, MUST NOT cite external sources."
-        ],
-        "_next_step": "Call 2_get_indicators(dataset) with the dataset that matches the user's query."
-    }
-
 if __name__ == "__main__":
-
-    # Startup banner with creator info
     log("\n" + "="*75)
     log("MoSPI MCP Server - Starting...")
     log("="*75)
     log("Serving Indian Government Statistical Data")
     log("Framework: FastMCP 3.0 with OpenTelemetry")
+    log("Tools: describe_dataset, get_data")
     log("Datasets: 7 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY)")
     log("="*75)
-
-    log("="*75)
     log("Server will be available at http://localhost:8000/mcp")
-    log("Telemetry: IP tracking + Input/Output capture enabled")
     log("="*75 + "\n")
 
-    # Run with HTTP transport for remote access
-    # For stdio (local MCP clients): mcp.run()
-    # For HTTP (remote/web access): mcp.run(transport="http", port=8000)
     mcp.run(transport="http", port=8000)

--- a/tests/eval_api.py
+++ b/tests/eval_api.py
@@ -1,0 +1,373 @@
+"""
+Programmatic eval for MoSPI MCP 2-tool design.
+
+Sends natural language queries to Claude API with tool definitions,
+executes tools locally (no MCP server needed), and checks whether
+Claude's final response contains the expected golden value.
+
+Usage:
+    python tests/eval_api.py                    # Run all golden queries
+    python tests/eval_api.py --query 3          # Run a single query by number
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import anthropic
+
+# Add project root to path so we can import mospi modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from mospi.search import search_dataset
+from mospi.client import mospi
+
+# ---------------------------------------------------------------------------
+# Golden eval set — query + expected value
+# ---------------------------------------------------------------------------
+# Expected values were computed by running the correct API queries manually.
+# The eval checks whether Claude's final response contains this value.
+
+GOLDEN_QUERIES = [
+    {
+        "dataset": "PLFS",
+        "query": "What is the unemployment rate for rural males in Bihar during 2022-23?",
+        "expected": "4.40",
+        "note": "UR, rural, male, Bihar, 2022-23, PS+SS, 15+",
+    },
+    {
+        "dataset": "PLFS",
+        "query": "What percentage of workers are in the manufacturing sector in Gujarat for females 2021-22?",
+        "expected": "17.71",
+        "note": "Pct distribution of workers, manufacturing, Gujarat, female, PS+SS, all ages",
+    },
+    {
+        "dataset": "CPI",
+        "query": "What is the CPI for food and beverages in rural India for January 2023?",
+        "expected": "175.0",
+        "note": "CPI group Food+Bev overall, rural, All India, Jan 2023, base 2012",
+    },
+    {
+        "dataset": "CPI",
+        "query": "CPI fuel and light combined sector delhi 2019 march",
+        "expected": "111.9",
+        "note": "CPI group Fuel+Light, combined, Delhi, Mar 2019, base 2012",
+    },
+    {
+        "dataset": "WPI",
+        "query": "What is the wholesale price index for primary articles in January 2023?",
+        "expected": "174.3",
+        "note": "WPI major_group primary articles, Jan 2023",
+    },
+    {
+        "dataset": "WPI",
+        "query": "What is the WPI for fuel and power in June 2022?",
+        "expected": "167.1",
+        "note": "WPI major_group fuel & power, Jun 2022",
+    },
+    {
+        "dataset": "IIP",
+        "query": "What is the index of industrial production for mining sector in 2022-23?",
+        "expected": "119.9",
+        "note": "IIP sectoral, mining, 2022-23, base 2011-12",
+    },
+    {
+        "dataset": "ASI",
+        "query": "How many textile factories were operating in Maharashtra in 2022-23?",
+        "expected": "1221",
+        "note": "ASI indicator=2 (factories), NIC 13 (textiles), Maharashtra, 2022-23",
+    },
+    {
+        "dataset": "ASI",
+        "query": "show me gross value added for textile industry across all states 2020-21",
+        "expected": "7135367",
+        "note": "ASI indicator=19 (GVA), NIC 13 (textiles), 2020-21, SUM across states",
+    },
+    {
+        "dataset": "NAS",
+        "query": "What was India's GDP at market prices in 2023-24 at current prices, current series, in crores?",
+        "expected": "296,57,744.74",
+        "note": "NAS GDP at market prices, current series, annual, 2023-24, current_price in Rs Crore",
+    },
+    {
+        "dataset": "ENERGY",
+        "query": "What was India's total coal production in 2023-24 in KToE?",
+        "expected": "403799.46",
+        "note": "Energy balance KToE, supply, coal, production, 2023-24",
+    },
+    {
+        "dataset": "ENERGY",
+        "query": "Diesel consumption by transport sector in petajoules for 2022-23",
+        "expected": "113.33",
+        "note": "Energy balance PJ, consumption, diesel, transport sector total, 2022-23",
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Tool definitions (matching @mcp.tool schemas from mospi_server.py)
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "name": "describe_dataset",
+        "description": (
+            "Search a MoSPI dataset for indicators and filter values.\n\n"
+            "Datasets: PLFS (employment), CPI (inflation), IIP (industrial production),\n"
+            "ASI (factory data), NAS (GDP), WPI (wholesale prices), ENERGY.\n\n"
+            "search_terms: case-insensitive search across all indicators and filters.\n"
+            "Be liberal — include synonyms, abbreviations, and related terms.\n"
+            "e.g., for \"unemployment in Maharashtra\":\n"
+            '  search_terms=["unemployment", "UR", "maharashtra", "2022", "2023"]\n\n'
+            "Returns matching codes to use in get_data(), plus any required params\n"
+            "you didn't search for with their full option lists."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "dataset": {"type": "string"},
+                "search_terms": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["dataset", "search_terms"],
+        },
+    },
+    {
+        "name": "get_data",
+        "description": (
+            "Fetch data from a MoSPI dataset. Use codes from describe_dataset().\n"
+            'Pass limit (e.g., "50", "100") if you expect many records.'
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "dataset": {"type": "string"},
+                "filters": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+            },
+            "required": ["dataset", "filters"],
+        },
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Tool execution (replicates mospi_server.py routing logic)
+# ---------------------------------------------------------------------------
+
+DATASET_MAP = {
+    "CPI_GROUP": "CPI_Group",
+    "CPI_ITEM": "CPI_Item",
+    "IIP_ANNUAL": "IIP_Annual",
+    "IIP_MONTHLY": "IIP_Monthly",
+    "PLFS": "PLFS",
+    "ASI": "ASI",
+    "NAS": "NAS",
+    "WPI": "WPI",
+    "ENERGY": "Energy",
+}
+
+
+def execute_tool(name: str, args: dict) -> dict:
+    """Execute a tool call by dispatching to our Python functions."""
+    if name == "describe_dataset":
+        return search_dataset(args["dataset"], args["search_terms"])
+
+    elif name == "get_data":
+        dataset = args["dataset"].upper()
+        filters = {k: str(v) for k, v in args.get("filters", {}).items() if v is not None}
+
+        if dataset == "CPI":
+            dataset = "CPI_ITEM" if "item_code" in filters else "CPI_GROUP"
+        if dataset == "IIP":
+            dataset = "IIP_MONTHLY" if "month_code" in filters else "IIP_ANNUAL"
+
+        api_dataset = DATASET_MAP.get(dataset)
+        if not api_dataset:
+            return {"error": f"Unknown dataset: {dataset}"}
+
+        result = mospi.get_data(api_dataset, filters)
+
+        if isinstance(result, dict) and result.get("msg") == "No Data Found":
+            result["hint"] = (
+                "No data for this filter combination. Try: "
+                "1) Remove optional filters one at a time. "
+                "2) Use describe_dataset() to verify your codes are correct. "
+                "3) Try a broader filter (e.g., group level instead of item level)."
+            )
+        return result
+
+    return {"error": f"Unknown tool: {name}"}
+
+
+# ---------------------------------------------------------------------------
+# Claude API tool-use loop
+# ---------------------------------------------------------------------------
+
+def run_query(client: anthropic.Anthropic, query: str, max_turns: int = 10) -> dict:
+    """Send a query to Claude with tools, run the tool loop, return results."""
+    messages = [{"role": "user", "content": query}]
+    tool_calls = []
+
+    for _ in range(max_turns):
+        try:
+            response = client.messages.create(
+                model="claude-sonnet-4-5-20250929",
+                max_tokens=4096,
+                tools=TOOLS,
+                messages=messages,
+            )
+        except Exception as e:
+            return {"text": "", "tool_calls": tool_calls, "error": str(e)}
+
+        assistant_text = ""
+        tool_use_blocks = []
+        for block in response.content:
+            if block.type == "text":
+                assistant_text += block.text
+            elif block.type == "tool_use":
+                tool_use_blocks.append(block)
+
+        if response.stop_reason == "end_turn":
+            return {"text": assistant_text, "tool_calls": tool_calls}
+
+        if response.stop_reason == "tool_use":
+            tool_results = []
+            for block in tool_use_blocks:
+                print(f"      -> {block.name}({json.dumps(block.input, default=str)[:120]})")
+                try:
+                    result = execute_tool(block.name, block.input)
+                except Exception as e:
+                    result = {"error": str(e)}
+
+                tool_calls.append({
+                    "name": block.name,
+                    "input": block.input,
+                    "output": result,
+                })
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": json.dumps(result, default=str),
+                })
+
+            messages.append({"role": "assistant", "content": response.content})
+            messages.append({"role": "user", "content": tool_results})
+
+    return {"text": "", "tool_calls": tool_calls, "error": "max_turns_exceeded"}
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def normalize_number(s: str) -> float:
+    """Parse a number string, stripping commas and whitespace."""
+    return float(s.replace(",", "").strip())
+
+
+def value_in_response(expected: str, response_text: str) -> bool:
+    """Check if the expected value appears in Claude's response."""
+    if not response_text:
+        return False
+
+    response_clean = response_text.replace(",", "")
+
+    try:
+        expected_float = normalize_number(expected)
+    except ValueError:
+        return expected in response_text
+
+    # Try common formats of the number
+    formats = [
+        str(expected_float),                                    # 4.4
+        f"{expected_float:.1f}",                                # 4.4
+        f"{expected_float:.2f}",                                # 4.40
+        str(int(expected_float)) if expected_float == int(expected_float) else None,  # 4
+        f"{expected_float:,.0f}",                               # 25,822
+        f"{expected_float:,.2f}",                               # 403,799.46
+    ]
+
+    for fmt in formats:
+        if fmt and fmt in response_clean:
+            return True
+
+    # Also try the raw expected string
+    if expected.replace(",", "") in response_clean:
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="MoSPI MCP eval via Claude API")
+    parser.add_argument("--query", type=int, help="Run a single query by number (1-indexed)")
+    args = parser.parse_args()
+
+    client = anthropic.Anthropic()
+
+    queries = GOLDEN_QUERIES
+    if args.query:
+        if 1 <= args.query <= len(queries):
+            queries = [queries[args.query - 1]]
+        else:
+            print(f"Query number must be 1-{len(GOLDEN_QUERIES)}")
+            sys.exit(1)
+
+    print(f"Running {len(queries)} golden queries against Claude API (Sonnet 4.5)")
+    print(f"Scoring: PASS = expected value appears in Claude's response\n")
+
+    results = []
+    for i, q in enumerate(queries):
+        ds = q["dataset"]
+        query_text = q["query"]
+        expected = q["expected"]
+
+        print(f"  [{i+1}/{len(queries)}] [{ds}] {query_text[:65]}...")
+        print(f"    expected: {expected}")
+
+        t0 = time.time()
+        result = run_query(client, query_text)
+        elapsed = time.time() - t0
+
+        response_text = result.get("text", "")
+        passed = value_in_response(expected, response_text)
+
+        results.append({
+            "dataset": ds,
+            "query": query_text,
+            "expected": expected,
+            "passed": passed,
+            "num_calls": len(result.get("tool_calls", [])),
+            "elapsed": round(elapsed, 1),
+            "response_preview": response_text[:150].replace("\n", " ") if response_text else "(empty)",
+        })
+
+        status = "PASS" if passed else "FAIL"
+        print(f"    {status}  [{results[-1]['num_calls']} calls, {elapsed:.1f}s]")
+        if response_text:
+            print(f"    response: {response_text[:120].replace(chr(10), ' ')}...")
+        print()
+
+    # Summary
+    print("=" * 70)
+    total = len(results)
+    passed = sum(1 for r in results if r["passed"])
+
+    print(f"\n{'#':<4} {'Dataset':<8} {'Expected':<16} {'Result':<6} {'Calls':<6}")
+    print("-" * 50)
+    for i, r in enumerate(results):
+        status = "PASS" if r["passed"] else "FAIL"
+        print(f"{i+1:<4} {r['dataset']:<8} {r['expected']:<16} {status:<6} {r['num_calls']:<6}")
+
+    print("-" * 50)
+    print(f"\nPASSED: {passed}/{total} ({100*passed/total:.0f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 """
 Test client for MoSPI MCP Server
-Tests HTTP transport
+Tests HTTP transport with new 2-tool design
 """
 import asyncio
 from fastmcp import Client
@@ -10,35 +10,58 @@ async def test_server():
 
     # Connect to the HTTP server
     async with Client("http://localhost:8000/mcp") as client:
-        print("✅ Connected to MoSPI MCP Server\n")
+        print("Connected to MoSPI MCP Server\n")
 
         # Test 1: List available tools
-        print("📋 Available tools:")
+        print("Available tools:")
         tools = await client.list_tools()
         for tool in tools:
             print(f"   - {tool.name}")
         print(f"\n   Total: {len(tools)} tools\n")
 
-        # Test 2: Call 1_know_about_mospi_api
-        print("🔍 Testing 1_know_about_mospi_api...")
-        result = await client.call_tool("1_know_about_mospi_api", {})
-        print(f"   ✅ Success! Got {len(str(result))} characters of documentation\n")
+        # Test 2: describe_dataset — PLFS search
+        print("Testing describe_dataset (PLFS)...")
+        result = await client.call_tool("describe_dataset", {
+            "dataset": "PLFS",
+            "search_terms": ["unemployment", "maharashtra", "2022"]
+        })
+        print(f"   Result: {str(result)[:200]}...\n")
 
-        # Test 3: Call 2_get_indicators
-        print("🔍 Testing 2_get_indicators...")
-        result = await client.call_tool(
-            "2_get_indicators",
-            {
-                "dataset": "PLFS",
-                "user_query": "test query"
+        # Test 3: describe_dataset — WPI search
+        print("Testing describe_dataset (WPI)...")
+        result = await client.call_tool("describe_dataset", {
+            "dataset": "WPI",
+            "search_terms": ["rice", "paddy"]
+        })
+        print(f"   Result: {str(result)[:200]}...\n")
+
+        # Test 4: describe_dataset — CPI search
+        print("Testing describe_dataset (CPI)...")
+        result = await client.call_tool("describe_dataset", {
+            "dataset": "CPI",
+            "search_terms": ["food", "delhi"]
+        })
+        print(f"   Result: {str(result)[:200]}...\n")
+
+        # Test 5: get_data — PLFS unemployment rate
+        print("Testing get_data (PLFS)...")
+        result = await client.call_tool("get_data", {
+            "dataset": "PLFS",
+            "filters": {
+                "indicator_code": "3",
+                "frequency_code": "1",
+                "state_code": "16",
+                "year": "2022-23",
+                "gender_code": "3",
+                "sector_code": "3",
             }
-        )
-        print(f"   ✅ Success! Result: {result}\n")
+        })
+        print(f"   Result: {str(result)[:200]}...\n")
 
-        print("🎉 All tests passed!")
+        print("All tests passed!")
 
 if __name__ == "__main__":
-    print("🚀 Testing MoSPI MCP Server (HTTP Transport)\n")
+    print("Testing MoSPI MCP Server (HTTP Transport)\n")
     print("Make sure the server is running:")
     print("  python mospi_server.py\n")
     print("-" * 60 + "\n")


### PR DESCRIPTION
## Summary

Reduces the MCP server from 4 sequential tools to 2, cutting most queries from 4-6 LLM round-trips to 2.

## Motivation

The problem with the 4-tool approach is that each tool call is a full LLM round-trip. Walking the LLM through a menu step-by-step (browse datasets -> pick indicator -> browse filters -> query) costs 4-6 calls minimum, but LLMs don't need that hand-holding -- they're good at picking the right codes from a large option set in one pass. Collapse the discovery into a single search, let the LLM assemble the query itself, and you get the same result in 2 calls. The bigger response payload is a fraction of the cost saved by eliminating round-trips.

## New Design

### `describe_dataset(dataset, search_terms)`
Replaces tools 1-3. Searches across all indicators and filter dimensions, returns matching codes with param names and hierarchy context.

### `get_data(dataset, filters)`
Same as before. Auto-routes CPI (group vs item) and IIP (annual vs monthly) based on filters provided.

## Eval

12 golden queries across all 7 datasets, scoring **12/12 on Sonnet 4.5**.

```bash
python tests/eval_api.py            # All 12 queries (~3 min)
python tests/eval_api.py --query 1  # Single query
```

Hits the Claude API directly with tool definitions, executes tools locally (no MCP server needed), and checks expected values in Claude's response.

## Changes

| File | Change |
|------|--------|
| `mospi_server.py` | 2-tool design with swagger validation and CPI/IIP auto-routing |
| `mospi/search.py` | New -- search with hierarchy awareness (ASI NIC levels, WPI commodity tree) |
| `mospi/cache.py` | New -- in-memory TTL cache for metadata |
| `tests/eval_api.py` | New -- golden eval harness |
| `tests/test_client.py` | Updated for new tool signatures |

## Note

The upstream MoSPI API appears to ignore the `sub_group_code` filter for WPI -- queries at that level return unrelated data. Queries at the `major_group_code` level work correctly.
