### PR TITLE
feat: CPI 2024 base year support

### DIFF
--- a/swagger/swagger_user_cpi.yaml
+++ b/swagger/swagger_user_cpi.yaml
@@ -25,6 +25,15 @@ paths:
           enum:
           - "2012"
           - "2010"
+          - "2024"
+      - name: series
+        required: true
+        in: query
+        schema:
+          default: Current
+          enum:
+          - Current
+          - Back
       - name: year
         in: query
         description: Enter the Year (format YYYY.Comma separated for multiple values)
@@ -40,6 +49,42 @@ paths:
         description: Enter the Item code
         schema:
           type: string
+      - name: state_code
+        in: query
+        description: Enter the State code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: sector_code
+        in: query
+        description: Enter the Sector code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: division_code
+        in: query
+        description: Enter the Division code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: class_code
+        in: query
+        description: Enter the Class code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: sub_class_code
+        in: query
+        description: Enter the Sub-class code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: imputation_code
+        in: query
+        description: Enter the Imputation code (Y/N for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^[YN](,[YN])*$
       - name: limit
         in: query
         description: Number of records per page (default 10)
@@ -116,6 +161,7 @@ paths:
           enum:
           - "2012"
           - "2010"
+          - "2024"
       - name: series
         required: true
         in: query
@@ -154,6 +200,30 @@ paths:
         description: Enter the Sector code (from 1-3.Comma separated for multiple values)
         schema:
           type: string
+      - name: division_code
+        in: query
+        description: Enter the Division code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: class_code
+        in: query
+        description: Enter the Class code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: sub_class_code
+        in: query
+        description: Enter the Sub-class code (for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: imputation_code
+        in: query
+        description: Enter the Imputation code (Y/N for base_year 2024. Comma separated for multiple values)
+        schema:
+          type: string
+          pattern: ^[YN](,[YN])*$
       - name: limit
         in: query
         description: Number of records per page (default 10)


### PR DESCRIPTION
## Summary
- Added base_year 2024 support for CPI with a new hierarchical structure
- Implemented unified endpoint routing for base_year 2024 data
- Added new parameters: division_code, class_code, sub_class_code, imputation_code
- Defaulted to latest base_year (2024) for accessing recent data (2026+)
- Updated Swagger with all base_year 2024 parameters

## Changes
1. **client.py**: Added get_cpi_base_years() and updated get_cpi_filters() with series_code
2. **mospi_server.py**: Changed default base_year to 2024 and added guidance notes
3. **swagger_user_cpi.yaml**: Added base_year 2024 enum and new hierarchical parameters