### PR TITLE
feat: Add NAS base_year support

### DIFF
--- a/mospi/client.py
+++ b/mospi/client.py
@@ -292,7 +292,19 @@ class MoSPI:
                 timeout=30
             )
             response.raise_for_status()
-            return response.json()
+            result = response.json()
+
+            # Add base_year info for consistency with CPI workflow
+            if "data" in result and isinstance(result["data"], dict):
+                result["data"]["base_year"] = [
+                    {"base_year": "2011-12"}
+                ]
+            result["_note"] = (
+                "NAS requires base_year in 3_get_metadata and 4_get_data. "
+                "Currently only base_year='2011-12' is available. "
+                "Pass base_year along with series, frequency_code, and indicator_code."
+            )
+            return result
         except requests.RequestException as e:
             return {"error": str(e), "statusCode": False}
 
@@ -300,7 +312,8 @@ class MoSPI:
         self,
         series: str = "Current",
         frequency_code: int = 1,
-        indicator_code: int = 1
+        indicator_code: int = 1,
+        base_year: str = "2011-12"
     ) -> Dict[str, Any]:
         """Fetch available NAS filters for given series/frequency/indicator.
 
@@ -308,8 +321,10 @@ class MoSPI:
             series: "Current" or "Back"
             frequency_code: 1 (Annually) or 2 (Quarterly, Current series only)
             indicator_code: Indicator code (1-22 for Annual, 1-11 for Quarterly)
+            base_year: Base year for constant price calculations (e.g. "2011-12")
         """
         params = {
+            "base_year": base_year,
             "series": series,
             "frequency_code": frequency_code,
             "indicator_code": indicator_code,

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -210,7 +210,7 @@ def get_metadata(
     Returns all valid filter values (states, years, quarters, etc.) to use in 4_get_data().
 
     MUST NOT pass params that don't belong to this function.
-    "Format" and "series" are NOT valid here (Format is for 4_get_data only, series is for NAS only).
+    "Format" is NOT valid here (Format is for 4_get_data only). "series" is valid for NAS and CPI only.
 
     Args:
         dataset: Dataset name - one of: PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY
@@ -221,7 +221,7 @@ def get_metadata(
                         2=Quarterly bulletin (different indicator set).
                         3=Monthly bulletin (2025+ only).
                         MUST NOT use 2 for quarterly data. Use 1 + quarter_code in 4_get_data().
-        base_year: REQUIRED for CPI ("2024"/"2012"/"2010"), IIP ("2011-12"/"2004-05"/"1993-94"). MUST NOT pass for PLFS, ASI, WPI.
+        base_year: REQUIRED for CPI ("2024"/"2012"/"2010"), IIP ("2011-12"/"2004-05"/"1993-94"), NAS ("2011-12"). MUST NOT pass for PLFS, ASI, WPI.
         level: REQUIRED for CPI ("Group"/"Item"). MUST NOT pass for other datasets.
         frequency: REQUIRED for IIP ("Annually"/"Monthly"). MUST NOT pass for other datasets.
         classification_year: REQUIRED for ASI ("2008"/"2004"/"1998"/"1987"). MUST NOT pass for other datasets.
@@ -290,7 +290,7 @@ def get_metadata(
         elif dataset == "NAS":
             if indicator_code is None:
                 return {"error": "indicator_code is required for NAS"}
-            result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code)
+            result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code, base_year=base_year or "2011-12")
             result["api_params"] = get_swagger_param_definitions("NAS")
             result["_next_step"] = _next
             return result
@@ -335,6 +335,7 @@ def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY)
         filters: Key-value pairs using 'id' values from 3_get_metadata().
                  PLFS MUST include frequency_code (1=Annual, 2=Quarterly, 3=Monthly).
+                 NAS MUST include base_year (e.g., "2011-12").
                  Pass limit (e.g., "50", "100") if you expect more than 10 records.
     """
     dataset = dataset.upper()
@@ -452,7 +453,7 @@ def know_about_mospi_api() -> Dict[str, Any]:
             },
             "NAS": {
                 "name": "National Accounts Statistics",
-                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. Both Current and Back series available.",
+                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. Both Current and Back series available. Requires base_year (currently '2011-12').",
                 "use_for": "GDP, economic growth, national income, sectoral contribution, macro analysis"
             },
             "WPI": {

--- a/swagger/swagger_user_nas.yaml
+++ b/swagger/swagger_user_nas.yaml
@@ -16,6 +16,15 @@ paths:
       - National Accounts Statistics.
       operationId: NASIndicatorValues.
       parameters:
+      - name: base_year
+        required: true
+        in: query
+        description: Base year for constant price calculations
+        schema:
+          type: string
+          default: "2011-12"
+          enum:
+          - "2011-12"
       - name: series
         required: true
         in: query


### PR DESCRIPTION
## Summary
  - Add base_year parameter to NAS API (currently '2011-12')
  - Return base_year info in step2 (get_indicators) for consistency with CPI workflow
  - Pass base_year through step3 (get_metadata) and step4 (get_data)
  - Update swagger spec, tool docstrings, and step1 overview

  ## Files changed
  - `swagger/swagger_user_nas.yaml` — added base_year param
  - `mospi/client.py` — get_nas_indicators returns base_year info, get_nas_filters accepts base_year
  - `mospi_server.py` — pass base_year in step3 routing, updated docstrings