### PR TITLE
feat: NAS base_year 2022-23 + stateless HTTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ EXPOSE 8000
 
 # Run the server with OpenTelemetry instrumentation wrapper
 # FastMCP middleware handles IP tracking and input/output capture
-CMD ["opentelemetry-instrument", "fastmcp", "run", "mospi_server.py:mcp", "--transport", "http", "--port", "8000", "--host", "0.0.0.0"]
+CMD ["opentelemetry-instrument", "fastmcp", "run", "mospi_server.py:mcp", "--transport", "http", "--port", "8000", "--host", "0.0.0.0", "--stateless"]

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -297,11 +297,13 @@ class MoSPI:
             # Add base_year info for consistency with CPI workflow
             if "data" in result and isinstance(result["data"], dict):
                 result["data"]["base_year"] = [
-                    {"base_year": "2011-12"}
+                    {"base_year": "2022-23"},
+                    {"base_year": "2011-12"},
                 ]
             result["_note"] = (
                 "NAS requires base_year in 3_get_metadata and 4_get_data. "
-                "Currently only base_year='2011-12' is available. "
+                "Available base years: '2022-23' (latest) and '2011-12'. "
+                "DEFAULT to '2022-23' for recent data unless user specifies otherwise. "
                 "Pass base_year along with series, frequency_code, and indicator_code."
             )
             return result
@@ -313,7 +315,7 @@ class MoSPI:
         series: str = "Current",
         frequency_code: int = 1,
         indicator_code: int = 1,
-        base_year: str = "2011-12"
+        base_year: str = "2022-23"
     ) -> Dict[str, Any]:
         """Fetch available NAS filters for given series/frequency/indicator.
 
@@ -321,7 +323,7 @@ class MoSPI:
             series: "Current" or "Back"
             frequency_code: 1 (Annually) or 2 (Quarterly, Current series only)
             indicator_code: Indicator code (1-22 for Annual, 1-11 for Quarterly)
-            base_year: Base year for constant price calculations (e.g. "2011-12")
+            base_year: Base year - "2022-23" (latest) or "2011-12"
         """
         params = {
             "base_year": base_year,

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -221,7 +221,7 @@ def get_metadata(
                         2=Quarterly bulletin (different indicator set).
                         3=Monthly bulletin (2025+ only).
                         MUST NOT use 2 for quarterly data. Use 1 + quarter_code in 4_get_data().
-        base_year: REQUIRED for CPI ("2024"/"2012"/"2010"), IIP ("2011-12"/"2004-05"/"1993-94"), NAS ("2011-12"). MUST NOT pass for PLFS, ASI, WPI.
+        base_year: REQUIRED for CPI ("2024"/"2012"/"2010"), IIP ("2011-12"/"2004-05"/"1993-94"), NAS ("2022-23"/"2011-12"). MUST NOT pass for PLFS, ASI, WPI.
         level: REQUIRED for CPI ("Group"/"Item"). MUST NOT pass for other datasets.
         frequency: REQUIRED for IIP ("Annually"/"Monthly"). MUST NOT pass for other datasets.
         classification_year: REQUIRED for ASI ("2008"/"2004"/"1998"/"1987"). MUST NOT pass for other datasets.
@@ -290,7 +290,7 @@ def get_metadata(
         elif dataset == "NAS":
             if indicator_code is None:
                 return {"error": "indicator_code is required for NAS"}
-            result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code, base_year=base_year or "2011-12")
+            result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code, base_year=base_year or "2022-23")
             result["api_params"] = get_swagger_param_definitions("NAS")
             result["_next_step"] = _next
             return result
@@ -335,7 +335,7 @@ def get_data(dataset: str, filters: Dict[str, str]) -> Dict[str, Any]:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY)
         filters: Key-value pairs using 'id' values from 3_get_metadata().
                  PLFS MUST include frequency_code (1=Annual, 2=Quarterly, 3=Monthly).
-                 NAS MUST include base_year (e.g., "2011-12").
+                 NAS MUST include base_year ("2022-23" or "2011-12").
                  Pass limit (e.g., "50", "100") if you expect more than 10 records.
     """
     dataset = dataset.upper()
@@ -453,7 +453,7 @@ def know_about_mospi_api() -> Dict[str, Any]:
             },
             "NAS": {
                 "name": "National Accounts Statistics",
-                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. Both Current and Back series available. Requires base_year (currently '2011-12').",
+                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. Both Current and Back series available. Requires base_year ('2022-23' latest, or '2011-12').",
                 "use_for": "GDP, economic growth, national income, sectoral contribution, macro analysis"
             },
             "WPI": {
@@ -504,4 +504,4 @@ if __name__ == "__main__":
     # Run with HTTP transport for remote access
     # For stdio (local MCP clients): mcp.run()
     # For HTTP (remote/web access): mcp.run(transport="http", port=8000)
-    mcp.run(transport="http", port=8000)
+    mcp.run(transport="http", port=8000, stateless_http=True)

--- a/swagger/swagger_user_nas.yaml
+++ b/swagger/swagger_user_nas.yaml
@@ -22,8 +22,9 @@ paths:
         description: Base year for constant price calculations
         schema:
           type: string
-          default: "2011-12"
+          default: "2022-23"
           enum:
+          - "2022-23"
           - "2011-12"
       - name: series
         required: true
@@ -44,9 +45,10 @@ paths:
       - name: indicator_code
         required: true
         in: query
-        description: Enter the Indicator code (from 1 to 22. Comma separated for multiple values)
+        description: Enter the Indicator code (from 1 to 22, single value only)
         schema:
           type: string
+          pattern: ^\d+$
       - name: quarterly_code
         in: query
         description: Enter the Quarterly code (from 1 to 4. Comma separated for multiple values)


### PR DESCRIPTION
## Summary - Add NAS base_year 2022-23 as new default (latest), keep 2011-12 as fallback - Add --stateless flag to Dockerfile and stateless_http=True to server — fixes ChatGPT MCP connector Missing session ID error - Fix NAS indicator_code swagger to enforce single value only