### PR TITLE
fix: ChatGPT Accept header rejection (json_response=True)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE 8000
 
 # Run the server with OpenTelemetry instrumentation wrapper
 # FastMCP middleware handles IP tracking and input/output capture
-CMD ["opentelemetry-instrument", "fastmcp", "run", "mospi_server.py:mcp", "--transport", "http", "--port", "8000", "--host", "0.0.0.0", "--stateless"]
+CMD ["opentelemetry-instrument", "python", "mospi_server.py"]

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -782,4 +782,4 @@ if __name__ == "__main__":
     # Run with HTTP transport for remote access
     # For stdio (local MCP clients): mcp.run()
     # For HTTP (remote/web access): mcp.run(transport="http", port=8000)
-    mcp.run(transport="http", port=8000, stateless_http=True)
+    mcp.run(transport="http", host="0.0.0.0", port=8000, stateless_http=True, json_response=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # FastMCP 3.0 beta - includes OpenTelemetry telemetry support
 # Note: 3.0 is still in beta, pin to specific version for stability
 fastmcp==3.0.0b1
+mcp==1.26.0
 
 # Core dependencies
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- ChatGPT backend sends \`Accept: application/json\` only — \`mcp\` SDK 1.26.0 introduced strict validation that rejects this with 406, causing TaskGroup exception and 424 on
ChatGPT's \`refresh_actions\` endpoint
- Switched Dockerfile CMD to \`python mospi_server.py\` so \`mcp.run()\` config is actually applied (fastmcp CLI runner bypasses \`__main__\` block)
- Added \`json_response=True\` and \`host=\"0.0.0.0\"\` to \`mcp.run()\`
- Pinned \`mcp==1.26.0\` to prevent silent SDK breakage in future builds

## Test plan
- [ ] Deploy to prod via \`bash deploy.sh\` after merge
- [ ] In ChatGPT, disconnect and reconnect the MoSPI connector
- [ ] Verify no 424 errors on \`refresh_actions\` in browser dev console
- [ ] Test a query end-to-end (e.g. \"get latest GDP data using MoSPI MCP\")