### PR TITLE
fix: set listChanged=false to fix ChatGPT 424 connector error

### DIFF
--- a/mospi_server.py
+++ b/mospi_server.py
@@ -65,6 +65,13 @@ def log(msg: str):
 # Initialize FastMCP server
 mcp = FastMCP("MoSPI Data Server")
 
+# Disable listChanged notifications — ChatGPT opens a persistent GET SSE stream
+# when listChanged:true, waiting for notifications that never come in stateless mode,
+# causing 424 errors. Setting to false tells ChatGPT not to subscribe.
+mcp._mcp_server.notification_options.tools_changed = False
+mcp._mcp_server.notification_options.prompts_changed = False
+mcp._mcp_server.notification_options.resources_changed = False
+
 # Add telemetry middleware for IP tracking and input/output capture
 mcp.add_middleware(TelemetryMiddleware())
 
@@ -782,4 +789,4 @@ if __name__ == "__main__":
     # Run with HTTP transport for remote access
     # For stdio (local MCP clients): mcp.run()
     # For HTTP (remote/web access): mcp.run(transport="http", port=8000)
-    mcp.run(transport="http", host="0.0.0.0", port=8000, stateless_http=True, json_response=True)
+    mcp.run(transport="http", host="0.0.0.0", port=8000, stateless_http=True)


### PR DESCRIPTION
## Root Cause
ChatGPT opens a persistent GET SSE stream when server capabilities include \`listChanged:true\`. In stateless mode, the server never sends notifications, so ChatGPT's stream
hangs → times out → 424 on \`refresh_actions\`.

## Changes
- Set \`tools_changed\`, \`prompts_changed\`, \`resources_changed\` to \`False\` on \`mcp._mcp_server.notification_options\` — tells ChatGPT not to subscribe for notifications
- Remove \`json_response=True\` — return SSE format like all working ChatGPT MCP integrations (datagouv, OpenAI examples)

## References
- OpenAI Developer Community: 424/TaskGroup errors thread (confirmed fix: \`listChanged:false\`)
- datagouv-mcp (working reference): uses official mcp SDK which defaults to \`listChanged:false\`
- gen_mcp issue #8: real ChatGPT HTTP traffic logs showing GET stream after initialize

## After merge
1. Run \`bash deploy.sh\` on server
2. Add \`proxy_set_header Accept "application/json, text/event-stream";\` to nginx location blocks
3. Reconnect MoSPI connector in ChatGPT