### PR TITLE
fix: correct PLFS swagger with verified API behavior

### DIFF
--- a/mospi_server.py
+++ b/mospi_server.py
@@ -65,6 +65,13 @@ def log(msg: str):
 # Initialize FastMCP server
 mcp = FastMCP("MoSPI Data Server")
 
+# Disable listChanged notifications — ChatGPT opens a persistent GET SSE stream
+# when listChanged:true, waiting for notifications that never come in stateless mode,
+# causing 424 errors. Setting to false tells ChatGPT not to subscribe.
+mcp._mcp_server.notification_options.tools_changed = False
+mcp._mcp_server.notification_options.prompts_changed = False
+mcp._mcp_server.notification_options.resources_changed = False
+
 # Add telemetry middleware for IP tracking and input/output capture
 mcp.add_middleware(TelemetryMiddleware())
 
@@ -782,4 +789,4 @@ if __name__ == "__main__":
     # Run with HTTP transport for remote access
     # For stdio (local MCP clients): mcp.run()
     # For HTTP (remote/web access): mcp.run(transport="http", port=8000)
-    mcp.run(transport="http", host="0.0.0.0", port=8000, stateless_http=True, json_response=True)
+    mcp.run(transport="http", host="0.0.0.0", port=8000, stateless_http=True)

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -376,12 +376,16 @@ def step3_get_metadata(
                 "dataset": "PLFS",
                 "filter_values": filters,
                 "api_params": get_swagger_param_definitions("PLFS"),
-                "_note": "frequency_code selects the indicator SET, NOT time granularity. "
-                         "frequency_code=1 (Annual): Indicators 1-8 (LFPR, WPR, UR, wages, worker distribution, employment conditions). "
-                         "Already has quarterly breakdowns — use quarter_code to filter by quarter. "
-                         "frequency_code=2 (Quarterly bulletin): Different indicators for quarterly bulletin tables only. "
-                         "Use ONLY when the user explicitly asks for quarterly bulletin specific data. "
-                         "MUST pass the correct frequency_code in step4_get_data().",
+                "_note": "frequency_code selects the indicator SET, NOT just time granularity. "
+                         "CRITICAL: indicator_code MUST be a single integer — comma-separated causes 500 error for ALL frequency codes. Make one step4 call per indicator. "
+                         "frequency_code=1 (Annual, 2017-18 to 2023-24): Indicators 1=LFPR, 2=WPR, 3=UR, 4=Worker distribution, 5=Employment conditions, 6=Salaried wages, 7=Casual wages, 8=Self-employment earnings. "
+                         "Year format: YYYY-YY (e.g. 2023-24). state_code=99 for All India. Supports religion/social_category/education/weekly_status filters. "
+                         "frequency_code=2 (Quarterly bulletin, 2017-18 to 2025-26): Indicators 1-3 only. Year format: YYYY-YY. quarter_code: 2=JUL-SEP, 3=OCT-DEC, 4=JAN-MAR, 5=APR-JUN. "
+                         "Use ONLY when user explicitly asks for quarterly bulletin. "
+                         "frequency_code=3 (Monthly, 2025 onwards): Indicators 1-3 only. Year format: plain YYYY (e.g. 2025). Do NOT use YYYY-YY format. "
+                         "MUST pass the correct frequency_code in step4_get_data(). "
+                         "For latest data: use frequency_code=3 (Monthly) — most recent. "
+                         "ALWAYS use state_code=99 for All India; omitting state_code returns ALL states (far more records).",
                 "_next_step": _next,
             }
 

--- a/swagger/swagger_user_plfs.yaml
+++ b/swagger/swagger_user_plfs.yaml
@@ -17,153 +17,203 @@ paths:
       - name: indicator_code
         required: true
         in: query
-        description: Enter the Indicator Code (1 - 8)
+        description: >
+          Indicator code. SINGLE VALUE ONLY — comma-separated causes 500 error for all frequency codes.
+          frequency_code=1 (Annual): 1=LFPR, 2=WPR, 3=UR, 4=Percentage distribution of workers,
+          5=Employment conditions of regular wage/salaried employees, 6=Average salaried wage/salary earnings (₹/month),
+          7=Average casual labour wage earnings (₹/day), 8=Average self-employment gross earnings (₹/month).
+          frequency_code=2 (Quarterly bulletin): 1=LFPR, 2=WPR, 3=UR only (codes 4-8 not available).
+          frequency_code=3 (Monthly): 1=LFPR, 2=WPR, 3=UR only (codes 4-8 not available).
         schema:
-          type: integer
-          pattern: ^\d+(,\d+)*$
+          type: string
+          pattern: ^\d+$
       - name: frequency_code
         required: true
         in: query
-        description: Enter the Frequency Code (1 - Annually, 2 - Quarterly, 3 - Monthly)
+        description: >
+          Controls which indicator SET is available — not just time granularity.
+          1 = Annual (indicators 1-8, data from 2017-18 to 2023-24, financial year format).
+          2 = Quarterly bulletin (indicators 1-3 only, data from 2017-18 to 2025-26 by quarter, financial year format).
+          3 = Monthly (indicators 1-3 only, data from 2025 onwards, plain calendar year format).
+          Use frequency_code=3 for latest/recent data. Use frequency_code=2 only when user explicitly asks for quarterly bulletin.
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
+          pattern: ^\d+$
       - name: year
         in: query
-        description: Enter the Financial Year (format YYYY-YY. Comma separated for
-          multiple values)
+        description: >
+          Year filter. Format depends on frequency_code:
+          frequency_code=1 (Annual): financial year YYYY-YY (e.g. "2023-24"). Data: 2017-18 to 2023-24.
+          frequency_code=2 (Quarterly bulletin): financial year YYYY-YY (e.g. "2024-25"). Data: 2017-18 to 2025-26.
+          frequency_code=3 (Monthly): plain calendar year YYYY (e.g. "2025", "2026"). Do NOT use YYYY-YY for monthly.
+          Comma-separated for multiple values.
         schema:
           type: string
-          pattern: ^\d{4}-\d{2}(,\d{4}-\d{2})*$
+          pattern: ^\d{4}(-\d{2})?(,\d{4}(-\d{2})?)*$
       - name: month_code
         in: query
-        description: Enter the Month code (from 1 to 12. Comma separated for multiple
-          values)
+        description: >
+          Only for frequency_code=3 (Monthly). Do NOT pass for Annual or Quarterly bulletin.
+          1=January, 2=February, 4=April, 5=May, 6=June, 7=July, 8=August, 9=September,
+          10=October, 11=November, 12=December. March (code 3) data added when released.
+          Comma-separated for multiple values.
         schema:
           type: string
           pattern: ^\d+(,\d+)*$
       - name: state_code
         in: query
-        description: Enter the State code (from 1 to 38. Comma separated for multiple
-          values)
+        description: >
+          State code. Valid codes: 1-38 (individual states/UTs) and 99 (All India aggregate).
+          Use state_code=99 for All India. Omitting state_code returns ALL states (many more records).
+          Note: frequency_code=2 (Quarterly bulletin) has fewer states available — use step3 to check.
+          Comma-separated for multiple values.
         schema:
           type: string
           pattern: ^\d+(,\d+)*$
       - name: gender_code
         in: query
-        description: Enter the Gender code (from 1 to 3. Comma separated for multiple
-          values)
+        description: >
+          1=Male, 2=Female, 3=Person (all genders combined). Default to 3 unless user asks for gender breakdown.
+          Available for all frequency codes. Comma-separated for multiple values.
         schema:
           type: string
           pattern: ^\d+(,\d+)*$
       - name: age_code
         in: query
-        description: Enter the Age code (from 1 to 4. Comma separated for multiple
-          values)
+        description: >
+          Age group code.
+          frequency_code=1 (Annual): 1=15 years and above, 2=15-29 years, 3=15-59 years, 4=all.
+          frequency_code=2 and 3: 1=15 years and above, 2=15-29 years, 4=all. Code 3 (15-59) not available.
+          Default to 4 (all) unless user asks for age breakdown. Comma-separated for multiple values.
         schema:
           type: string
           pattern: ^\d+(,\d+)*$
       - name: sector_code
         in: query
-        description: Enter the Sector code (from 1 to 3. Comma separated for multiple
-          values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: weekly_status_code
-        in: query
-        description: Enter the Weekly Status code (from 1 to 2. Comma separated for
-          multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: religion_code
-        in: query
-        description: Enter the Religion code (from 1 to 5. Comma separated for multiple
-          values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: social_category_code
-        in: query
-        description: Enter the Social category code (from 1 to 5. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: education_code
-        in: query
-        description: Enter the Education code (from 1 to 10. Comma separated for multiple
-          values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: broad_industry_work_code
-        in: query
-        description: Enter the Broad industry work code (from 1 to 4. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: broad_status_employment_code
-        in: query
-        description: Enter the Broad status employment code (from 1 to 6. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: employee_contract_code
-        in: query
-        description: Enter the Employee contract code (from 1 to 5. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: enterprise_size_code
-        in: query
-        description: Enter the Enterprise size code (from 1 to 6. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: enterprise_type_code
-        in: query
-        description: Enter the Enterprise type code (from 1 to 9. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: industry_section_code
-        in: query
-        description: Enter the Industry section code (from 1 to 22. Comma separated
-          for multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: nco_division_code
-        in: query
-        description: Enter the NCO division code (from 1 to 11. Comma separated for
-          multiple values)
-        schema:
-          type: string
-          pattern: ^\d+(,\d+)*$
-      - name: nic_group_code
-        in: query
-        description: Enter the NIC group code (from 1 to 14. Comma separated for multiple
-          values)
+        description: >
+          1=Rural, 2=Urban, 3=Rural+Urban combined. Default to 3 unless user asks for rural/urban breakdown.
+          Available for all frequency codes. Comma-separated for multiple values.
         schema:
           type: string
           pattern: ^\d+(,\d+)*$
       - name: quarter_code
         in: query
-        description: Enter the Quarter code (from 1 to 35. Comma separated for multiple
-          values)
+        description: >
+          Quarter filter. Actual codes: 2=JUL-SEP, 3=OCT-DEC, 4=JAN-MAR, 5=APR-JUN.
+          For frequency_code=1 (Annual): only useful for indicator_codes 6, 7, 8 (wage indicators that have quarterly breakdowns). Indicators 1-3 show "quarter: all" and are unaffected.
+          For frequency_code=2 (Quarterly bulletin): use to filter by specific quarter.
+          Do NOT use for frequency_code=3 (Monthly) — use month_code instead.
+          Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: weekly_status_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual). Not available for Quarterly bulletin or Monthly.
+          1=PS+SS (principal + subsidiary status), 2=CWS (current weekly status).
+          Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: religion_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual). Not available for Quarterly bulletin or Monthly.
+          1=All, 2=Hinduism, 3=Islam, 4=Christianity, 5=Sikhism.
+          Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: social_category_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual). Not available for Quarterly bulletin or Monthly.
+          1=All, 2=Scheduled Tribe, 3=Scheduled Caste, 4=Other Backward Class, 5=Others.
+          Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: education_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual). Not available for Quarterly bulletin or Monthly.
+          1=Not literate, 2=Literate & upto primary, 3=Middle, 4=Secondary, 5=Higher secondary,
+          6=Diploma/certificate, 7=Graduate, 8=Post graduate & above, 9=Secondary & above, 10=All.
+          Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: broad_industry_work_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-4. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: broad_status_employment_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-6. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: employee_contract_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=5 (Employment conditions of regular wage/salaried employees).
+          Returns empty for any other indicator_code or frequency. Codes 1-5. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: enterprise_size_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-6. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: enterprise_type_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-9. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: industry_section_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-22. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: nco_division_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-11. Comma-separated for multiple values.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
+      - name: nic_group_code
+        in: query
+        description: >
+          Only for frequency_code=1 (Annual) AND indicator_code=4 (Percentage distribution of workers).
+          Returns empty for any other indicator_code or frequency. Codes 1-14. Comma-separated for multiple values.
         schema:
           type: string
           pattern: ^\d+(,\d+)*$
       - name: limit
         in: query
-        description: Number of records per page (default 10)
+        description: >
+          Records per page (default 10). IMPORTANT: 10 is too low for most queries.
+          Use 50+ for monthly data (11 records/indicator), 100+ for quarterly/annual with breakdowns.
+          Annual indicator_code=4 can have 1000+ records across all breakdown dimensions.
         schema:
           type: integer
           pattern: ^\d+$


### PR DESCRIPTION
## Summary
- `indicator_code`: single value only — comma-separated causes 500 on **all** frequency codes
- `year`: support both `YYYY` (monthly) and `YYYY-YY` (annual/quarterly) formats; pattern and description fixed
- `state_code`: add code `99` = All India; note that omitting returns all states (unexpected high record counts)
- `quarter_code`: correct actual codes to 2–5 (was documented as "1 to 35"); scoped to fc=1 wage indicators and fc=2
- `month_code`: scoped to fc=3 only
- `age_code`: code 3 (15-59 yrs) only in fc=1; fc=2 and fc=3 don't have it
- `weekly_status`, `religion`, `social_category`, `education`: marked fc=1 only
- 8 breakdown filters (`broad_industry`, `enterprise_*`, etc.): scoped to fc=1 + specific indicator_codes
- `limit`: recommend 50+; note indicator_code=4 has 1000+ records
- All 8 indicator names documented with actual names from API responses
- `_note` in server updated with complete per-frequency guidance

## Test plan
- [ ] All changes verified with live API calls before committing
- [ ] Monthly fetch (fc=3): single indicator_code, plain YYYY year, state_code=99
- [ ] Annual fetch (fc=1): state_code=99 returns All India only; omitting returns all states
- [ ] Quarterly bulletin (fc=2): quarter_code 2-5 confirmed working
- [ ] Indicator_code=4 annual: breakdown filters confirmed annual-only