### PR TITLE
feat: upgrade FastMCP 3.1.1 + structuredContent

### DIFF
--- a/mospi_server.py
+++ b/mospi_server.py
@@ -187,7 +187,7 @@ def transform_filters(filters: Dict[str, Any]) -> Dict[str, str]:
     return result
 
 
-@mcp.tool(name="step2_get_indicators")
+@mcp.tool(name="step2_get_indicators", annotations={"readOnlyHint": True, "destructiveHint": False, "openWorldHint": True})
 def step2_get_indicators(
     dataset: str,
     user_query: Optional[str] = None,
@@ -198,7 +198,7 @@ def step2_get_indicators(
     level: Optional[str] = None,
     series: Optional[str] = None,
     Format: Optional[str] = None
-):
+) -> dict:
     """
     ============================================================
     RULES (MUST follow exactly):
@@ -278,7 +278,7 @@ def step2_get_indicators(
     return result
 
 
-@mcp.tool(name="step3_get_metadata")
+@mcp.tool(name="step3_get_metadata", annotations={"readOnlyHint": True, "destructiveHint": False, "openWorldHint": True})
 def step3_get_metadata(
     dataset: str,
     indicator_code: Optional[int] = None,
@@ -292,7 +292,7 @@ def step3_get_metadata(
     sub_indicator_code: Optional[int] = None,
     Format: Optional[str] = None,
     type: Optional[str] = None
-):
+) -> dict:
     """
     ============================================================
     RULES (MUST follow exactly):
@@ -521,8 +521,8 @@ def step3_get_metadata(
         return {"error": str(e)}
 
 
-@mcp.tool(name="step4_get_data")
-def step4_get_data(dataset: str, filters: Dict[str, Any]):
+@mcp.tool(name="step4_get_data", annotations={"readOnlyHint": True, "destructiveHint": False, "openWorldHint": True})
+def step4_get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     """
     ============================================================
     RULES (MUST follow exactly):
@@ -628,8 +628,8 @@ def step4_get_data(dataset: str, filters: Dict[str, Any]):
 
 
 # Comprehensive API documentation tool
-@mcp.tool(name="step1_know_about_mospi_api")
-def step1_know_about_mospi_api():
+@mcp.tool(name="step1_know_about_mospi_api", annotations={"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False})
+def step1_know_about_mospi_api() -> dict:
     """
     ============================================================
     RULES (MUST follow exactly):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-# FastMCP 3.0 beta - includes OpenTelemetry telemetry support
-# Note: 3.0 is still in beta, pin to specific version for stability
-fastmcp==3.0.0b1
-mcp==1.26.0
+# FastMCP 3.1 - structured content support for ChatGPT app compatibility
+fastmcp==3.1.1
 
 # Core dependencies
 requests>=2.31.0


### PR DESCRIPTION
## Summary
- Upgrade FastMCP from 3.0.0b1 to 3.1.1
- Add -> dict return type hints to all 4 MCP tools, enabling structuredContent in tool responses
- Required for official ChatGPT app registry compatibility

## Test plan
- [x] Server starts on FastMCP 3.1.1
- [x] listChanged: false still works
- [x] All 4 tools advertise outputSchema
- [x] Tool calls return both structuredContent and content