### PR TITLE
fix: skip SSL verification for upstream API requests

### DIFF
--- a/mospi/client.py
+++ b/mospi/client.py
@@ -35,6 +35,7 @@ class MoSPI:
             respect_retry_after_header=True,
         )
         adapter = HTTPAdapter(max_retries=retry)
+        self.session.verify = False
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
         self.api_endpoints = {


### PR DESCRIPTION
## Summary
- Skip SSL verification for upstream MoSPI API requests
- Fixes EC (Economic Census) failures caused by misconfigured SSL chain on `esankhyiki.mospi.gov.in`

## Context
The `esankhyiki.mospi.gov.in` server was renewed with an eMudhra cert but includes a self-signed root in the chain, causing SSL verification failures on Linux environments
(GitHub Actions, Docker).

## Test plan
- [ ] EC dataset queries return data successfully
- [ ] All other datasets unaffected