### PR TITLE
ci: test with Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies


### PR DESCRIPTION
Diagnosing whether CI test failures are caused by the SSL fix breaking on Python 3.11 vs a network issue. If tests pass on 3.12, the SSL context is the culprit.