### PR TITLE
chore: add AI PR auto-review (free, via GitHub Models)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,219 @@
+name: AI PR Review
+
+# Uses GitHub Models (free in Actions) to auto-review every PR against main.
+# Flags blocking issues, suggestions, and nits. Posts a single summary
+# comment per PR and updates it on subsequent commits.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  models: read  # required for GitHub Models inference
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gather diff
+        id: context
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=50 origin "$BASE_REF"
+          # Cap diff at 150 KB to stay well under model context.
+          DIFF=$(git diff "origin/${BASE_REF}...${HEAD_SHA}" | head -c 150000)
+          CHANGED=$(git diff --name-only "origin/${BASE_REF}...${HEAD_SHA}")
+          {
+            echo "diff<<DIFFEOF"
+            echo "$DIFF"
+            echo "DIFFEOF"
+            echo "changed<<CHGEOF"
+            echo "$CHANGED"
+            echo "CHGEOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run AI review
+        id: ai
+        uses: actions/ai-inference@v2
+        with:
+          model: openai/gpt-5
+          max-completion-tokens: 3000
+          system-prompt: |
+            You are an expert code reviewer for the MoSPI MCP server, a
+            FastMCP 3.0 server that exposes 23 Indian government statistical
+            datasets over the Model Context Protocol. Production:
+            https://mcp.mospi.gov.in/. Single-file design (mospi_server.py);
+            swagger YAMLs are the source of truth for parameter validation.
+
+            ## Architecture invariants
+            - 4-tool workflow, in order: list_datasets -> get_indicators ->
+              get_metadata -> get_data. Skipping a step yields invalid filter
+              codes.
+            - validate_filters() reads swagger at request time. Do not
+              hardcode parameter lists.
+            - The `--stateless` flag in the Dockerfile CMD is non-negotiable
+              (ChatGPT's MCP connector requires it).
+
+            ## When a dataset is added, the following must ALL be updated:
+            Code:
+              1. swagger/swagger_user_<name>.yaml — full param schema with
+                 proper types; multi-value patterns ^\d+(,\d+)*$ preserved
+              2. mospi/client.py — api_endpoints entry, get_<name>_indicators
+                 method, get_<name>_filters method (if applicable)
+              3. mospi_server.py — VALID_DATASETS, DATASET_SWAGGER,
+                 DATASETS_REQUIRING_INDICATOR (if applicable), indicator_methods
+                 dict, get_metadata branch, dataset_map in get_data,
+                 list_datasets entry with name+description+use_for,
+                 total_datasets count, startup banner log line, and the
+                 get_indicators/get_metadata/get_data docstring dataset lists.
+            Tests:
+              4. tests/test_mcp_server.py — pytest.param in DATASETS, entry in
+                 EXPECTED_DATASETS, docstring "all N datasets" updates.
+            Docs:
+              5. README.md — Key Features count, dataset table row, "all N
+                 datasets" comments.
+              6. CONTRIBUTING.md — "currently supports N datasets" lines.
+              7. CHANGELOG.md — Unreleased entry; version history table.
+
+            ## Common renames callers should NOT see:
+            - RBI: caller sends indicator_code -> upstream needs
+              sub_indicator_code. Renamed in get_data.
+            - MNRE: caller sends indicator_code -> upstream needs
+              type_of_renewable_energy_code. Renamed in get_data.
+            - NSS80: caller sends indicator_code -> upstream needs both
+              indicator_code AND survey_code. survey_code auto-derived from
+              indicator_code range (1-20=CMST, 23-42=CMSE) in get_data.
+
+            ## Known pitfalls to flag if regressed
+            - Dataset count drift: total appears in ~9 places. Use
+              `rg -n '\b\d+ datasets?\b'`-style mental check.
+            - nginx CSP newline trap: Content-Security-Policy value MUST be
+              on one physical line; a literal newline corrupts the HTTP
+              response.
+            - nginx add_header inheritance: any child location with its own
+              add_header silently drops server-level add_header. Use
+              default_type instead of add_header Content-Type when possible.
+            - FastMCP doesn't enforce type hints. Numeric params must use
+              _safe_int() before being passed upstream.
+            - CPI tests pinned to base_year=2012 due to upstream 2024
+              endpoint regression. Do not switch back.
+            - MoSPI API uses legacy TLS renegotiation; do not replace the
+              LegacyRenegotiationAdapter with plain requests.
+
+            ## Review focus, in priority order
+            1. Correctness — does the code do what the PR claims?
+            2. Dataset wiring — if a dataset is added/renamed/removed, every
+               one of the locations above must be updated.
+            3. Test coverage — new datasets and new code paths need pytest
+               entries.
+            4. Documentation consistency — total dataset count and dataset
+               name lists must match across all files.
+            5. Security — no leaked secrets, no SQL/command injection, no
+               overly permissive nginx/CSP changes.
+            6. Swagger drift — required params marked, comma-separated
+               regex patterns preserved, param names match what the client
+               sends after any rename.
+
+            ## Severity
+              BLOCKING — must fix before merge (correctness, broken wiring,
+                missing critical piece, security risk).
+              SUGGESTION — nice-to-have improvement.
+              NIT — stylistic preference (use sparingly).
+
+            ## What NOT to flag
+            - Formatting that a linter would catch.
+            - Suggestions to split mospi_server.py — single-file is intentional.
+            - Suggestions to add runtime type-hint enforcement — FastMCP
+              intentionally doesn't, and _safe_int() is the pattern.
+            - Suggestions to remove 'unsafe-inline' from CSP — explicitly
+              accepted in the May 2026 KPMG VA.
+            - Tests against upstream MoSPI API behavior the API doesn't
+              guarantee — test_get_data already accepts the API as oracle.
+
+            ## Output format (Markdown)
+
+            ## Summary
+            One sentence on what the PR does and overall verdict.
+
+            ## Findings
+            For each issue:
+              - **[BLOCKING/SUGGESTION/NIT]** `path:line` — concise issue.
+                Why it matters in one sentence. Suggested fix in one line.
+
+            ## Verdict
+            - Blocking count: N
+            - Suggestion count: N
+            - Nit count: N
+            - Recommendation: Approve / Request Changes / Comment
+            - One-sentence rationale.
+
+            If there are no findings, say so explicitly and recommend Approve.
+          prompt: |
+            Review this pull request.
+
+            Title: ${{ github.event.pull_request.title }}
+
+            Description:
+            ${{ github.event.pull_request.body }}
+
+            Changed files:
+            ${{ steps.context.outputs.changed }}
+
+            Diff:
+            ```diff
+            ${{ steps.context.outputs.diff }}
+            ```
+
+      - name: Post or update review comment
+        uses: actions/github-script@v7
+        env:
+          REVIEW: ${{ steps.ai.outputs.response }}
+        with:
+          script: |
+            const marker = '<!-- ai-pr-review -->';
+            const body = `${marker}\n## 🤖 AI PR Review\n\n${process.env.REVIEW}\n\n---\n_Auto-generated by [GitHub Models](https://docs.github.com/en/github-models) via \`.github/workflows/ai-review.yml\`. Add the \`skip-review\` label to suppress._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  models: read  # required for GitHub Models inference
+  models: read
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number }}
@@ -42,8 +42,8 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags --depth=50 origin "$BASE_REF"
-          # Cap diff at 150 KB to stay well under model context.
-          DIFF=$(git diff "origin/${BASE_REF}...${HEAD_SHA}" | head -c 150000)
+          # Cap diff at 20 KB (~5000 tokens) to fit in gpt-4o's 8000-token input budget
+          DIFF=$(git diff "origin/${BASE_REF}...${HEAD_SHA}" | head -c 20000)
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...${HEAD_SHA}")
           {
             echo "diff<<DIFFEOF"
@@ -58,121 +58,71 @@ jobs:
         id: ai
         uses: actions/ai-inference@v2
         with:
-          model: openai/gpt-5
-          max-completion-tokens: 3000
+          # gpt-4o gives 8000 input tokens (vs 4000 for gpt-5/o3/o4-mini) on the
+          # GitHub Models free tier — best fit for PR review where context matters.
+          model: openai/gpt-4o
+          max-completion-tokens: 2000
           system-prompt: |
-            You are an expert code reviewer for the MoSPI MCP server, a
-            FastMCP 3.0 server that exposes 23 Indian government statistical
-            datasets over the Model Context Protocol. Production:
-            https://mcp.mospi.gov.in/. Single-file design (mospi_server.py);
-            swagger YAMLs are the source of truth for parameter validation.
+            You are reviewing a PR on the MoSPI MCP server: a FastMCP 3.0
+            server exposing 23 Indian govt statistical datasets over the
+            Model Context Protocol. Single-file server (mospi_server.py).
+            Swagger YAMLs are the source of truth for parameter validation.
 
-            ## Architecture invariants
-            - 4-tool workflow, in order: list_datasets -> get_indicators ->
-              get_metadata -> get_data. Skipping a step yields invalid filter
-              codes.
-            - validate_filters() reads swagger at request time. Do not
-              hardcode parameter lists.
-            - The `--stateless` flag in the Dockerfile CMD is non-negotiable
-              (ChatGPT's MCP connector requires it).
+            ## Project rules — flag any violation
 
-            ## When a dataset is added, the following must ALL be updated:
-            Code:
-              1. swagger/swagger_user_<name>.yaml — full param schema with
-                 proper types; multi-value patterns ^\d+(,\d+)*$ preserved
-              2. mospi/client.py — api_endpoints entry, get_<name>_indicators
-                 method, get_<name>_filters method (if applicable)
-              3. mospi_server.py — VALID_DATASETS, DATASET_SWAGGER,
-                 DATASETS_REQUIRING_INDICATOR (if applicable), indicator_methods
-                 dict, get_metadata branch, dataset_map in get_data,
-                 list_datasets entry with name+description+use_for,
-                 total_datasets count, startup banner log line, and the
-                 get_indicators/get_metadata/get_data docstring dataset lists.
-            Tests:
-              4. tests/test_mcp_server.py — pytest.param in DATASETS, entry in
-                 EXPECTED_DATASETS, docstring "all N datasets" updates.
-            Docs:
-              5. README.md — Key Features count, dataset table row, "all N
-                 datasets" comments.
-              6. CONTRIBUTING.md — "currently supports N datasets" lines.
-              7. CHANGELOG.md — Unreleased entry; version history table.
+            **Dataset wiring** — adding a dataset requires updates in ALL of:
+            swagger/swagger_user_<name>.yaml; mospi/client.py (api_endpoints,
+            get_<n>_indicators, get_<n>_filters); mospi_server.py
+            (VALID_DATASETS, DATASET_SWAGGER, DATASETS_REQUIRING_INDICATOR,
+            indicator_methods dict, get_metadata branch, dataset_map in
+            get_data, list_datasets entry, total_datasets count, banner log,
+            docstrings); tests/test_mcp_server.py (DATASETS pytest.param,
+            EXPECTED_DATASETS); README.md, CONTRIBUTING.md, CHANGELOG.md
+            (dataset count + lists).
 
-            ## Common renames callers should NOT see:
-            - RBI: caller sends indicator_code -> upstream needs
-              sub_indicator_code. Renamed in get_data.
-            - MNRE: caller sends indicator_code -> upstream needs
-              type_of_renewable_energy_code. Renamed in get_data.
-            - NSS80: caller sends indicator_code -> upstream needs both
-              indicator_code AND survey_code. survey_code auto-derived from
-              indicator_code range (1-20=CMST, 23-42=CMSE) in get_data.
+            **Param renames** done in get_data (caller sends indicator_code):
+            RBI -> sub_indicator_code; MNRE -> type_of_renewable_energy_code;
+            NSS80 also needs survey_code auto-derived (1-20=CMST, 23-42=CMSE).
 
-            ## Known pitfalls to flag if regressed
-            - Dataset count drift: total appears in ~9 places. Use
-              `rg -n '\b\d+ datasets?\b'`-style mental check.
-            - nginx CSP newline trap: Content-Security-Policy value MUST be
-              on one physical line; a literal newline corrupts the HTTP
-              response.
-            - nginx add_header inheritance: any child location with its own
-              add_header silently drops server-level add_header. Use
-              default_type instead of add_header Content-Type when possible.
-            - FastMCP doesn't enforce type hints. Numeric params must use
-              _safe_int() before being passed upstream.
-            - CPI tests pinned to base_year=2012 due to upstream 2024
-              endpoint regression. Do not switch back.
-            - MoSPI API uses legacy TLS renegotiation; do not replace the
-              LegacyRenegotiationAdapter with plain requests.
-
-            ## Review focus, in priority order
-            1. Correctness — does the code do what the PR claims?
-            2. Dataset wiring — if a dataset is added/renamed/removed, every
-               one of the locations above must be updated.
-            3. Test coverage — new datasets and new code paths need pytest
-               entries.
-            4. Documentation consistency — total dataset count and dataset
-               name lists must match across all files.
-            5. Security — no leaked secrets, no SQL/command injection, no
-               overly permissive nginx/CSP changes.
-            6. Swagger drift — required params marked, comma-separated
-               regex patterns preserved, param names match what the client
-               sends after any rename.
+            **Pitfalls**:
+            - Dataset count drift across files
+            - nginx CSP value MUST be one physical line (newline = HTTP corruption)
+            - nginx add_header in a child location silently drops server-level headers
+            - FastMCP doesn't enforce type hints; use _safe_int() for numeric params
+            - CPI tests pin base_year=2012 due to upstream 2024 regression
+            - Don't replace LegacyRenegotiationAdapter (MoSPI needs legacy TLS)
+            - --stateless flag in Dockerfile CMD is required for ChatGPT
 
             ## Severity
-              BLOCKING — must fix before merge (correctness, broken wiring,
-                missing critical piece, security risk).
-              SUGGESTION — nice-to-have improvement.
-              NIT — stylistic preference (use sparingly).
+            - **BLOCKING** — correctness, broken wiring, missing critical
+              piece, security risk
+            - **SUGGESTION** — nice-to-have
+            - **NIT** — stylistic (use sparingly)
 
-            ## What NOT to flag
-            - Formatting that a linter would catch.
-            - Suggestions to split mospi_server.py — single-file is intentional.
-            - Suggestions to add runtime type-hint enforcement — FastMCP
-              intentionally doesn't, and _safe_int() is the pattern.
-            - Suggestions to remove 'unsafe-inline' from CSP — explicitly
-              accepted in the May 2026 KPMG VA.
-            - Tests against upstream MoSPI API behavior the API doesn't
-              guarantee — test_get_data already accepts the API as oracle.
+            ## Don't flag
+            - Linter-style formatting
+            - Splitting mospi_server.py (single-file is intentional)
+            - Adding type-hint enforcement
+            - Removing 'unsafe-inline' from CSP (accepted in KPMG VA)
 
-            ## Output format (Markdown)
+            ## Output (Markdown)
 
             ## Summary
-            One sentence on what the PR does and overall verdict.
+            One sentence: what the PR does + verdict.
 
             ## Findings
-            For each issue:
-              - **[BLOCKING/SUGGESTION/NIT]** `path:line` — concise issue.
-                Why it matters in one sentence. Suggested fix in one line.
+            - **[BLOCKING/SUGGESTION/NIT]** `path:line` — issue. Why it
+              matters (1 sentence). Suggested fix (1 line).
 
             ## Verdict
-            - Blocking count: N
-            - Suggestion count: N
-            - Nit count: N
+            - Blocking: N
+            - Suggestion: N
+            - Nit: N
             - Recommendation: Approve / Request Changes / Comment
             - One-sentence rationale.
 
-            If there are no findings, say so explicitly and recommend Approve.
+            If no findings, say so and recommend Approve.
           prompt: |
-            Review this pull request.
-
             Title: ${{ github.event.pull_request.title }}
 
             Description:
@@ -193,7 +143,7 @@ jobs:
         with:
           script: |
             const marker = '<!-- ai-pr-review -->';
-            const body = `${marker}\n## 🤖 AI PR Review\n\n${process.env.REVIEW}\n\n---\n_Auto-generated by [GitHub Models](https://docs.github.com/en/github-models) via \`.github/workflows/ai-review.yml\`. Add the \`skip-review\` label to suppress._`;
+            const body = `${marker}\n## 🤖 AI PR Review\n\n${process.env.REVIEW}\n\n---\n_Auto-generated by [GitHub Models](https://docs.github.com/en/github-models) (openai/gpt-4o) via \`.github/workflows/ai-review.yml\`. Add the \`skip-review\` label to suppress._`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Adds a free PR auto-review workflow using GitHub Models. Every PR against \`main\` is reviewed by **GPT-4o** with a project-aware system prompt; the bot posts a single summary comment per PR and updates it on each push.

## Why

We have nine separate places where a new dataset must be wired in (\`VALID_DATASETS\`, \`DATASET_SWAGGER\`, \`DATASETS_REQUIRING_INDICATOR\`, \`indicator_methods\`, \`get_metadata\` branch, \`dataset_map\`, \`list_datasets\` entry, banner log, docstrings — plus tests, README, CONTRIBUTING, CHANGELOG). Past PRs have had count drift bugs (\`19 datasets\` / \`20 datasets\` / \`21 datasets\` mismatch found during MNRE work). A reviewer who knows the checklist is the cheapest defence.

## How it works

- Trigger: \`pull_request\` opened/sync/reopened/ready_for_review against \`main\`
- Action: \`actions/ai-inference@v2\`
- Model: **\`openai/gpt-4o\`** — picked because it has the largest input budget on the GitHub Models free tier (8000 input tokens, 50 PRs/day). \`gpt-5\` and \`o4-mini\` only allow 4000 input tokens, which doesn't fit our system prompt + diff.
- Auth: \`GITHUB_TOKEN\` — no API key secret needed
- Permissions: \`contents: read\`, \`pull-requests: write\`, \`issues: write\`, \`models: read\`
- Skips: draft PRs, dependabot, PRs labeled \`skip-review\`
- Concurrency: cancels in-flight reviews on rapid pushes (cost/rate-limit control)
- Posts a Markdown comment with sections: Summary, Findings (BLOCKING/SUGGESTION/NIT), Verdict. Hidden HTML marker (\`<!-- ai-pr-review -->\`) is used to find and update an existing comment so PRs don't accumulate stale reviews.

## What the prompt encodes

The system prompt inlines the project's institutional knowledge:
- 4-tool MCP architecture
- The 9-place dataset wiring checklist
- Known param renames in \`get_data\` (RBI \`sub_indicator_code\`, MNRE \`type_of_renewable_energy_code\`, NSS80 \`survey_code\` auto-derivation)
- Known pitfalls: dataset count drift, nginx CSP newline trap, \`add_header\` inheritance trap, FastMCP type-hint gotcha, CPI 2024 endpoint flake, MoSPI legacy TLS quirk, ChatGPT \`--stateless\` requirement
- What NOT to flag: linter-style nits, splitting \`mospi_server.py\`, removing \`unsafe-inline\` from CSP (accepted in KPMG VA)

## Cost

Zero. GitHub Models is free for use inside GitHub Actions. Rate limit (50 reviews/day for gpt-4o) is well above our PR cadence.

## Iteration history

1. First attempt used \`gpt-5\` and a longer prompt; failed with \`413 Request body too large\` because gpt-5 caps at 4000 input tokens on free tier.
2. Switched to gpt-4o (8000 input tokens) and trimmed prompt to ~1100 tokens. Diff capped at 20 KB. Now succeeds.