### PR TITLE
fix(ai-review): use temp file to avoid SIGPIPE on large diffs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -42,8 +42,14 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags --depth=50 origin "$BASE_REF"
+          # Capture full diff to a temp file, then truncate.
+          # Piping `git diff | head -c N` causes SIGPIPE (exit 141) under
+          # pipefail when the diff exceeds N bytes.
+          TMPDIFF=$(mktemp)
+          trap "rm -f $TMPDIFF" EXIT
+          git diff "origin/${BASE_REF}...${HEAD_SHA}" > "$TMPDIFF"
           # Cap diff at 20 KB (~5000 tokens) to fit in gpt-4o's 8000-token input budget
-          DIFF=$(git diff "origin/${BASE_REF}...${HEAD_SHA}" | head -c 20000)
+          DIFF=$(head -c 20000 "$TMPDIFF")
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...${HEAD_SHA}")
           {
             echo "diff<<DIFFEOF"


### PR DESCRIPTION
## Bug

When triggered on PR #33 (NSS80), \`ai-review\` failed with exit code 141 in the \"Gather diff\" step.

\`git diff | head -c 20000\` works on small diffs (PR #34's own diff was tiny) but causes SIGPIPE on larger PRs: \`head\` closes its stdin after reading 20 KB, \`git diff\` gets SIGPIPE on its next write and exits 141. With \`set -o pipefail\` in the script header, that propagates and fails the step.

## Fix

Capture the full diff to a temp file first, then truncate via \`head -c\`. Avoids the pipe entirely so SIGPIPE can't happen.

## Test plan

- Will be tested by the auto-trigger on this PR itself, plus a re-trigger on PR #33 afterwards.