### PR TITLE
fix(nss76): correct and complete filter params in swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- NSS76 (NSS 76th Round - Disability + Housing & Drinking Water) with 25 indicators across two modules: survey_code=1 (Disability, indicators 1-13) covering disability prevalence, literacy, education, employment, care arrangements, and receipt of aid/help; survey_code=2 (Housing & drinking water, indicators 14-26) covering drinking water sources, sufficiency, treatment, housing characteristics, latrines, and flood experience. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-76/getNSS76FilterByIndicatorId` (swagger documents data endpoint only).
+
 ### Changed
+- Total datasets: 23 → 24
+- list_datasets, get_indicators, and get_metadata updated to include NSS76
 - Upgraded fastmcp from 3.0.0b1 to 3.3.1, moving from a beta to a stable release. The mcp SDK is now resolved transitively by fastmcp and is no longer pinned in requirements.txt.
 - serverInfo now reports an explicit application version instead of the underlying framework version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Adding a New Dataset
 
-The server currently supports 23 datasets. To add a new one:
+The server currently supports 24 datasets. To add a new one:
 
 ### 1. Get the Swagger spec
 
@@ -111,7 +111,7 @@ pip install -r tests/requirements-test.txt
 pytest tests/ -v -p no:anyio
 ```
 
-This runs tests covering all 23 datasets across all 4 tools, plus negative/error-path tests. Tests hit the live MoSPI API with a 0.5s throttle between calls to avoid rate-limiting.
+This runs tests covering all 24 datasets across all 4 tools, plus negative/error-path tests. Tests hit the live MoSPI API with a 0.5s throttle between calls to avoid rate-limiting.
 
 To test against a deployed server instead of in-process:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ MCP (Model Context Protocol) server for accessing India's Ministry of Statistics
 This server provides AI-ready access to official Indian government statistics through the Model Context Protocol (MCP). It acts as a bridge between AI assistants (Claude, ChatGPT, Cursor, etc.) and MoSPI's open data APIs, enabling natural language queries for economic, demographic, and social indicators.
 
 **Key Features:**
-- 23 statistical datasets covering employment, inflation, industrial production, GDP, energy, renewable energy, higher education, school education, gender, health, environment, trade, agriculture, consumption, economic census, and digital literacy
+- 24 statistical datasets covering employment, inflation, industrial production, GDP, energy, renewable energy, higher education, school education, gender, health, disability, housing, environment, trade, agriculture, consumption, economic census, and digital literacy
 - Sequential 4-tool workflow designed for LLM consumption
 - Swagger-driven parameter validation
 - Full OpenTelemetry integration for observability
@@ -81,6 +81,7 @@ This server provides AI-ready access to official Indian government statistics th
 | **NSS79** | NSS 79th Round (CAMS + AYUSH) | Literacy, school enrolment, NEET youth, health expenditure, financial inclusion, digital skills, AYUSH awareness and usage |
 | **UDISE** | UDISE+ (Unified District Information System for Education) | Schools, enrolment, dropout rates, teachers, PTR, GER, NER, GPI, CWSN, school infrastructure, ICT labs, minority enrolment |
 | **MNRE** | Renewable Energy (Ministry of New and Renewable Energy) | State-wise monthly installed capacity (MW) for solar, wind, hydro, bio, and total renewable power |
+| **NSS76** | NSS 76th Round (Disability + Housing & Drinking Water) | Disability prevalence, literacy and education among PwD, care arrangements, aid/help, drinking water sources, water treatment, housing characteristics, latrines, flood experience |
 | **NSS80** | NSS 80th Round (Telecom (CMST) + Education (CMSE)) | Mobile phone ownership, internet usage, online banking, cybercrime, household telecom connectivity, school enrolment and expenditure course fees, private coaching | 
 <!-- | NMKN | National Namkeen Consumption Index | Bhujia per capita, sev consumption patterns, mixture preference by state | -->
 
@@ -264,7 +265,7 @@ mospi-mcp-api/
 │   └── swagger_user_*.yaml
 ├── observability/
 │   └── telemetry.py         # OpenTelemetry middleware for tracing
-├── tests/                   # Pytest suite (covering all 23 datasets)
+├── tests/                   # Pytest suite (covering all 24 datasets)
 ├── Dockerfile               # Production container with OTEL instrumentation
 ├── docker-compose.yml       # Full stack with Jaeger
 └── requirements.txt
@@ -288,7 +289,7 @@ pip install -r tests/requirements-test.txt
 pytest tests/ -v -p no:anyio
 ```
 
-Runs in-process against the MCP server (no running server needed). Covers all 23 datasets across all 4 tools. See [CONTRIBUTING.md](CONTRIBUTING.md#testing) for details.
+Runs in-process against the MCP server (no running server needed). Covers all 24 datasets across all 4 tools. See [CONTRIBUTING.md](CONTRIBUTING.md#testing) for details.
 
 ---
 

--- a/definitions/nss76_definitions.json
+++ b/definitions/nss76_definitions.json
@@ -1,0 +1,127 @@
+[
+  {
+    "indicator_code": 1,
+    "name": "Percentage of persons with disability for each State/ UT",
+    "description": "Percentage of persons with disability for each State/ UT"
+  },
+  {
+    "indicator_code": 2,
+    "name": "Percentage of persons with broad type of disability for each State/ UT",
+    "description": "Percentage of persons with broad type of disability for each State/ UT"
+  },
+  {
+    "indicator_code": 3,
+    "name": "Literacy rate (in per cent) of persons of age 7 years and above with disability for each State/ UT",
+    "description": "Literacy rate (in per cent) of persons of age 7 years and above with disability for each State/ UT"
+  },
+  {
+    "indicator_code": 4,
+    "name": "Percentage of persons of age 15 years and above with disability having highest level of completed education secondary and above for each State/ UT",
+    "description": "Percentage of persons of age 15 years and above with disability having highest level of completed education secondary and above for each State/ UT"
+  },
+  {
+    "indicator_code": 5,
+    "name": "Percentage of persons with disability having disability since birth for each State/UT",
+    "description": "Percentage of persons with disability having disability since birth for each State/UT"
+  },
+  {
+    "indicator_code": 6,
+    "name": "Percentage of persons with disability having disability not since birth for each State/UT",
+    "description": "Percentage of persons with disability having disability not since birth for each State/UT"
+  },
+  {
+    "indicator_code": 7,
+    "name": "Percentage of persons with disability by status of treatment taken for different broad type of disability for each State/UT",
+    "description": "Percentage of persons with disability by status of treatment taken for different broad type of disability for each State/UT"
+  },
+  {
+    "indicator_code": 8,
+    "name": "Percentage of persons with locomotor disability who were advised aid/appliances and acquired aid/appliances for each State/UT",
+    "description": "Percentage of persons with locomotor disability who were advised aid/appliances and acquired aid/appliances for each State/UT"
+  },
+  {
+    "indicator_code": 9,
+    "name": "Percentage of persons with visual disability who were advised aid/appliances and acquired aid/appliances for each State/UT",
+    "description": "Percentage of persons with visual disability who were advised aid/appliances and acquired aid/appliances for each State/UT"
+  },
+  {
+    "indicator_code": 10,
+    "name": "Percentage of persons with hearing disability who were advised aid/appliances and acquired aid/appliances for each State/UT",
+    "description": "Percentage of persons with hearing disability who were advised aid/appliances and acquired aid/appliances for each State/UT"
+  },
+  {
+    "indicator_code": 11,
+    "name": "Percentage distribution of persons with disability by arrangement of regular care giver for each State/UT",
+    "description": "Percentage distribution of persons with disability by arrangement of regular care giver for each State/UT"
+  },
+  {
+    "indicator_code": 12,
+    "name": "Percentage of persons with disability who used/ accessed public transport during last 365 days, accessed public building during last 365 days and problems faced in accessing/using publictransport/public building for each State/UT",
+    "description": "Percentage of persons with disability who used/ accessed public transport during last 365 days, accessed public building during last 365 days and problems faced in accessing/using publictransport/public building for each State/UT"
+  },
+  {
+    "indicator_code": 13,
+    "name": "Percentage distribution of persons with disability by receipt of aid/help for each State/UT",
+    "description": "Percentage distribution of persons with disability by receipt of aid/help for each State/UT"
+  },
+  {
+    "indicator_code": 14,
+    "name": "Percentage distribution of households not getting sufficient drinking water from the principal source by number of calendar months not getting sufficient drinking water, separately for households with different principal sources of drinking water",
+    "description": "Percentage distribution of households not getting sufficient drinking water from the principal source by number of calendar months not getting sufficient drinking water, separately for households with different principal sources of drinking water"
+  },
+  {
+    "indicator_code": 15,
+    "name": "Percentage distribution of households by supplementary sources of drinking water for different principal sources of drinking water",
+    "description": "Percentage distribution of households by supplementary sources of drinking water for different principal sources of drinking water"
+  },
+  {
+    "indicator_code": 16,
+    "name": "Percentage of households having improved source of drinking water",
+    "description": "Percentage of households having improved source of drinking water"
+  },
+  {
+    "indicator_code": 18,
+    "name": "Percentage of households which covered the main container used for storing drinking water",
+    "description": "Percentage of households which covered the main container used for storing drinking water"
+  },
+  {
+    "indicator_code": 19,
+    "name": "Percentage distribution of households by method of treatment of drinking water for different principal sources of drinking water",
+    "description": "Percentage distribution of households by method of treatment of drinking water for different principal sources of drinking water"
+  },
+  {
+    "indicator_code": 20,
+    "name": "Percentage of persons regularly used improved latrine",
+    "description": "Percentage of persons regularly used improved latrine"
+  },
+  {
+    "indicator_code": 21,
+    "name": "Percentage of households having bathroom and latrine within the household premises",
+    "description": "Percentage of households having bathroom and latrine within the household premises"
+  },
+  {
+    "indicator_code": 22,
+    "name": "Average plinth level of the house (0.00 mtr.)  for households living in houses",
+    "description": "Average plinth level of the house (0.00 mtr.)  for households living in houses"
+  },
+  {
+    "indicator_code": 23,
+    "name": "Average floor area (0.00 sq. mtr.) of the dwelling unit for households living in houses",
+    "description": "Average floor area (0.00 sq. mtr.) of the dwelling unit for households living in houses"
+  },
+  {
+    "indicator_code": 24,
+    "name": "Average number of living rooms of the households living in houses",
+    "description": "Average number of living rooms of the households living in houses"
+  },
+  {
+    "indicator_code": 25,
+    "name": "Percentage of households (living in a house) having separate kitchen with tap",
+    "description": "Percentage of households (living in a house) having separate kitchen with tap"
+  },
+  {
+    "indicator_code": 26,
+    "name": "Percentage distribution of households living in a house with direct opening to approach road / lane /constructed path",
+    "description": "Percentage distribution of households living in a house with direct opening to approach road / lane /constructed path"
+  }
+]

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -82,6 +82,7 @@ class MoSPI:
             "NSS78": "/api/nss-78/getNss78Records",
             "NSS79": "/api/nss-79/getNSS79Records",
             "NSS80": "/api/nss-80/getNSS80Records",
+            "NSS76": "/api/nss-76/getNss76Records",
             "CPIALRL": "/api/cpialrl/getCpialrlRecords",
             "HCES": "/api/hces/getHcesRecords",
             "TUS": "/api/tus/getTusRecords",
@@ -900,6 +901,92 @@ class MoSPI:
                 f"{self.base_url}/api/nss-79/getNSS79FilterByIndicatorId",
                 params=params,
                 timeout=30
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    # =========================================================================
+    # NSS76 (NSS 76th Round - Disability + Housing / Drinking Water) Methods
+    # =========================================================================
+    @staticmethod
+    def _nss76_survey_for(indicator_code: int) -> Optional[int]:
+        """
+        Map NSS76 indicator_code to survey_code.
+
+        survey_code=1 -> Disability statistics (indicators 1-13)
+        survey_code=2 -> Housing, drinking water, sanitation (indicators 14-26)
+        """
+        if 1 <= indicator_code <= 13:
+            return 1
+        if 14 <= indicator_code <= 26:
+            return 2
+        return None
+
+    def get_nss76_indicators(self) -> Dict[str, Any]:
+        """Fetch list of NSS76 indicators from MoSPI API.
+
+        Returns 25 indicators from NSS 76th Round — two survey modules combined:
+        - survey_code=1 (Disability): 13 indicators on disability prevalence,
+          literacy, education, employment, and aid for persons with disability.
+        - survey_code=2 (Housing & water): 12 indicators on drinking water,
+          housing characteristics, latrines, and household amenities.
+        """
+        try:
+            resp1 = self.session.get(
+                f"{self.base_url}/api/nss-76/getIndicatorList",
+                params={"survey_code": 1},
+                timeout=30,
+            )
+            resp1.raise_for_status()
+            result = resp1.json()
+
+            resp2 = self.session.get(
+                f"{self.base_url}/api/nss-76/getIndicatorList",
+                params={"survey_code": 2},
+                timeout=30,
+            )
+            resp2.raise_for_status()
+            housing = resp2.json().get("data", [])
+
+            result["data"] = result.get("data", []) + housing
+            result["count"] = len(result["data"])
+            result["_note"] = (
+                "survey_code=1 (Disability): indicators 1-13. "
+                "survey_code=2 (Housing & drinking water): indicators 14-26. "
+                "Pass survey_code in get_metadata/get_data or rely on auto-derivation from indicator_code."
+            )
+            return result
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    def get_nss76_filters(self, indicator_code: int, survey_code: Optional[int] = None) -> Dict[str, Any]:
+        """Fetch available NSS76 filters for given indicator.
+
+        Args:
+            indicator_code: Indicator code (1-26; 17 is unused in the API list).
+            survey_code: 1=Disability module, 2=Housing & drinking water module.
+                         Auto-derived from indicator_code if not supplied.
+        """
+        if survey_code is None:
+            survey_code = self._nss76_survey_for(indicator_code)
+            if survey_code is None:
+                return {
+                    "error": (
+                        f"Invalid indicator_code {indicator_code}. "
+                        "Valid ranges: 1-13 (Disability), 14-26 (Housing & water)."
+                    ),
+                    "statusCode": False,
+                }
+
+        params = {"indicator_code": indicator_code, "survey_code": survey_code}
+
+        try:
+            response = self.session.get(
+                f"{self.base_url}/api/nss-76/getNSS76FilterByIndicatorId",
+                params=params,
+                timeout=30,
             )
             response.raise_for_status()
             return response.json()

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -27,13 +27,15 @@ def _apply_definitions(indicators: list, definitions: Dict) -> None:
         code = indicator.get("indicator_code") or indicator.get("code")
         if code in definitions:
             indicator["definition"] = definitions[code].get("description", "")
+        elif indicator.get("label"):
+            indicator["definition"] = indicator["label"]
 
 
 def enrich_indicators(result: Dict[str, Any], dataset: str) -> Dict[str, Any]:
     """Enrich indicator list with definitions from definitions/ folder.
 
     Handles all response structures:
-    - result["data"] = flat list  (AISHE, GENDER, NFHS, ENVSTATS, RBI, NSS77, HCES, TUS, EC)
+    - result["data"] = flat list  (AISHE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS76, HCES, TUS, EC)
     - result["indicators_by_frequency"] = dict of lists  (PLFS, ASUSE)
     - result["data"]["indicator"] = list  (NAS, ENERGY, CPIALRL)
     - result["indicator"] = list  (NSS78)
@@ -78,7 +80,7 @@ mcp.add_middleware(TelemetryMiddleware())
 VALID_DATASETS = [
     "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
-    "NSS77", "NSS78", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
+    "NSS77", "NSS78", "NSS76", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
 ]
 
 # Maps dataset key -> (swagger_yaml_file, endpoint_path)
@@ -109,12 +111,13 @@ DATASET_SWAGGER = {
     "UDISE": ("swagger_user_udise.yaml", "/api/udise/getUdiseRecords"),
     "MNRE": ("swagger_user_mnre.yaml", "/api/mnre/getDataByEnergy"),
     "NSS80": ("swagger_user_nss80.yaml", "/api/nss-80/getNSS80Records"),
+    "NSS76": ("swagger_user_nss76.yaml", "/api/nss-76/getNss76Records"),
 }
 
 # Datasets that require indicator_code in get_data
 DATASETS_REQUIRING_INDICATOR = [
     "PLFS", "NAS", "ENERGY", "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS",
-    "NSS77", "NSS78", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE","NSS80"
+    "NSS77", "NSS78", "NSS76", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
 ]
 
 
@@ -252,7 +255,7 @@ def get_indicators(
     Args:
         dataset: Dataset name — one of: PLFS, CPI, IIP, ASI, NAS, WPI,
                  ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI,
-                 NSS77, NSS78, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
+                 NSS77, NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
                  For CPI, IIP, WPI: returns available base years and frequencies.
         user_query: The user's original question. Captured for telemetry analytics; not echoed back in the response.
 
@@ -286,6 +289,7 @@ def get_indicators(
         "EC": mospi.get_ec_indicators,
         "UDISE": mospi.get_udise_indicators,
         "MNRE": mospi.get_mnre_indicators,
+        "NSS76": mospi.get_nss76_indicators,
         "NSS80": mospi.get_nss80_indicators,
         # Special datasets - return guidance instead of indicators
         "CPI": mospi.get_cpi_base_years,
@@ -341,7 +345,7 @@ def get_metadata(
     Args:
         dataset: Dataset name (same values as get_indicators).
         indicator_code: Required for: PLFS, NAS, ENERGY, AISHE, ASUSE, GENDER,
-                        NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
+                        NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
                         Not applicable for: CPI, IIP, ASI, WPI.
                         For RBI, this maps to sub_indicator_code internally.
         frequency_code: Required for PLFS and ASUSE.
@@ -357,7 +361,8 @@ def get_metadata(
         classification_year: Required for ASI ("2008"/"2004"/"1998"/"1987").
         series: For CPI and NAS only ("Current"/"Back").
         use_of_energy_balance_code: For ENERGY only (1=Supply, 2=Consumption).
-        survey_code: For NSS80 only (1=Telecom (CMST), 2=Education (CMSE)).
+        survey_code: For NSS76 (1=Disability, 2=Housing & drinking water) and NSS80
+                     (1=Telecom (CMST), 2=Education (CMSE)).
 
     Returns:
         dict with 'filter_values' (valid codes for each parameter),
@@ -610,6 +615,23 @@ def get_metadata(
             result["next_step"] = _next
             return _check_empty_metadata(result, dataset, indicator_code=indicator_code)
         
+        elif dataset == "NSS76":
+            if indicator_code is None:
+                return {"error": "indicator_code is required for NSS76. Disability=1-13, Housing & water=14-26."}
+            survey_code, err = _safe_int(survey_code, "survey_code")
+            if err:
+                return err
+            result = mospi.get_nss76_filters(indicator_code=indicator_code, survey_code=survey_code)
+            result["api_params"] = get_swagger_param_definitions("NSS76")
+            result["parameter_notes"] = (
+                "survey_code is required by the data API. 1=Disability module (indicators 1-13), "
+                "2=Housing & drinking water module (indicators 14-26). "
+                "Auto-derived from indicator_code if omitted. "
+                "state_code=37 is All India. Filter keys use id/label (e.g. state, gender, sector)."
+            )
+            result["next_step"] = _next
+            return _check_empty_metadata(result, dataset, indicator_code=indicator_code, survey_code=survey_code)
+
         elif dataset == "NSS80":
             if indicator_code is None:
                 return {"error": "indicator_code is required for NSS80. CMST=1-20, CMSE=23-42."}
@@ -651,7 +673,7 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     Args:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY,
                  AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77,
-                 NSS78, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80).
+                 NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80).
                  CPI auto-routes to Group or Item endpoint based on
                  whether filters contain item_code.
                  IIP uses a single endpoint; pass frequency="Annually" or
@@ -706,6 +728,7 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
         "TUS": "TUS",
         "UDISE": "UDISE",
         "MNRE": "MNRE",
+        "NSS76": "NSS76",
         "NSS80": "NSS80",
     }
 
@@ -724,7 +747,18 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     if dataset == "MNRE" and "indicator_code" in transformed_filters:
         transformed_filters["type_of_renewable_energy_code"] = transformed_filters.pop("indicator_code")
 
-    # NSS80 requires survey_code; auto-derive from indicator_code if not supplied
+    # NSS76/NSS80 require survey_code; auto-derive from indicator_code if not supplied
+    if dataset == "NSS76" and "survey_code" not in transformed_filters:
+        ic = transformed_filters.get("indicator_code")
+        if ic is not None:
+            try:
+                ic_int = int(str(ic).split(",")[0])
+                derived = mospi._nss76_survey_for(ic_int)
+                if derived is not None:
+                    transformed_filters["survey_code"] = str(derived)
+            except (ValueError, AttributeError):
+                pass
+
     if dataset == "NSS80" and "survey_code" not in transformed_filters:
         ic = transformed_filters.get("indicator_code")
         if ic is not None:
@@ -780,7 +814,7 @@ def list_datasets() -> dict:
     This is the starting point — call this first to identify the right dataset.
 
     The API covers 500+ indicators across employment, prices, industry, national
-    accounts, health, education, environment, trade, and more. Each dataset has
+    accounts, health, education, disability, housing, environment, trade, and more. Each dataset has
     its own indicator codes, filter parameters, and valid values — these are not
     standardized and cannot be inferred or guessed from parameter names alone.
 
@@ -795,7 +829,7 @@ def list_datasets() -> dict:
         and 'workflow' (the four-step sequence).
     """
     return {
-        "total_datasets": 23,
+        "total_datasets": 24,
         "datasets": {
             "PLFS": {
                 "name": "Periodic Labour Force Survey",
@@ -907,6 +941,11 @@ def list_datasets() -> dict:
                 "description": "5 indicators on state-wise monthly installed renewable energy capacity (MW): 1=Solar Power (5 categories: ground-mounted, rooftop, hybrid, off-grid/KUSUM, total), 2=Wind Power (no categories), 3=Hydro Power (small, large), 4=Bio Power (waste-to-energy, biomass cogeneration, bagasse, off-grid, total), 5=Total Power (aggregate of all renewables). Coverage from 2020 onwards, 36 states/UTs plus All India, monthly granularity.",
                 "use_for": "Renewable energy capacity, solar power installed capacity, wind power, hydro power, bio power, rooftop solar, KUSUM, biomass, state-wise renewable energy, MNRE statistics, clean energy, green energy capacity"
             },
+            "NSS76": {
+                "name": "NSS76 (76th Round - Disability + Housing & Drinking Water)",
+                "description": "25 indicators from NSS 76th Round in two modules. Disability module (survey_code=1, indicators 1-13): prevalence of disability, literacy and education among persons with disability, employment, care arrangements, and receipt of aid/help by state/UT. Housing & water module (survey_code=2, indicators 14-26): principal and supplementary sources of drinking water, sufficiency of supply, treatment methods, housing characteristics (floor area, living rooms, plinth level, approach road, separate kitchen, floors), latrine use, and flood experience.",
+                "use_for": "Disability statistics, persons with disability literacy and education, care givers, aid and help for disabled, drinking water sources, water treatment, housing quality, latrine access, household amenities, flood experience, NSS 76th round"
+            },
             "NSS80": {
                 "name": "NSS80 (80th Round - Telecom (CMST) + Education (CMSE))",
                 "description": "38 indicators from two modules of NSS 80th Round. Telecom (CMST) module (Comprehensive Modular Survey: Telecom, indicators 1-20): mobile phone ownership and usage in last 3 months, internet usage and frequency, type of portable device and network used, ability to send/receive email and attachments, ability to copy-paste, create electronic documents and presentations, online banking ability and modes of transaction, ability to report cybercrime, household possession of landline/mobile/optical fiber, household internet facility by service type, reasons for not having internet, and household online purchases by type of goods. Education (CMSE) module (Comprehensive Modular Survey: Education, indicators 23-42): covers student enrolment patterns, type of school and level of enrolment, expenditure on school education including course fees, books, uniforms, transport and other related expenses, participation in private coaching and associated expenditure, household spending on education, sources of funding for educational expenses, distribution of students across education categories, and household support for school education.",
@@ -930,7 +969,7 @@ if __name__ == "__main__":
     log("="*75)
     log("Serving Indian Government Statistical Data")
     log("Framework: FastMCP 3.3 with OpenTelemetry")
-    log("Datasets: 23 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80)")
+    log("Datasets: 24 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80)")
     log("Server: http://localhost:8000/mcp")
     log("Telemetry: IP tracking + Input/Output capture enabled")
     log("="*75 + "\n")

--- a/swagger/swagger_user_nss76.yaml
+++ b/swagger/swagger_user_nss76.yaml
@@ -16,7 +16,10 @@ paths:
       description: |
         - **Required:** `indicator_code`
         - **Required in practice:** `survey_code` (1=Disability indicators 1-13, 2=Housing & drinking water indicators 14-26)
-        - **Filters (optional):** sub_indicator_code, state_code (37=All India), gender_code, sector_code, type_of_structure_code, supplementary_source_of_drinking_water_code, social_group_code, dwelling_units_code, agency_emptied_code, distribution_by_plinth_level_code, distribution_by_experience_of_flood_code, tenurial_status_code, principal_source_of_drinking_water_code, households_percentage_code, month_code, percentage_houses_number_floors_house_code, percentage_houses_separate_kitchen_code, quintile_class_code, type_of_approach_road_code, types_of_latrine_uses_code, method_of_treatment_of_water_code, water_facility_code, dwshhc_street_light_facility_water_facility_code, status_of_receipt_of_aid_help_code
+        - **Multi-value:** every filter `*_code` accepts comma-separated values (e.g. `state_code=1,2,3`)
+        - **Shared filters (optional):** sub_indicator_code, state_code (37=All India), sector_code, gender_code, quintile_class_code, month_code
+        - **Disability-module filters (survey_code=1):** disability_type_code, treatment_taken_code, arrangement_of_caregiver_code, use_of_public_transport_code, status_of_receipt_of_aid_help_code
+        - **Housing & water-module filters (survey_code=2):** principal_source_of_drinking_water_code, supplementary_source_of_drinking_water_code, method_of_treatment_of_water_code, households_percentage_code, number_of_days_code, type_of_structure_code, material_category_type_code, dwelling_units_code, tenurial_status_code, distribution_by_plinth_level_code, percentage_houses_number_floors_house_code, percentage_houses_separate_kitchen_code, type_of_approach_road_code, types_of_latrine_uses_code, agency_emptied_code, distribution_by_experience_of_flood_code
         - **Metadata/filters API (not in this path):** `/api/nss-76/getNSS76FilterByIndicatorId`
         - **Indicators API (not in this path):** `/api/nss-76/getIndicatorList?survey_code=1|2`
 
@@ -30,102 +33,175 @@ paths:
           name: survey_code
           schema: { type: string }
           description: Survey module code (1=Disability, 2=Housing & drinking water)
+
+        # --- Shared filters (apply across both modules) ---
         - in: query
           name: sub_indicator_code
-          schema: { type: integer }
-          description: Enter the sub-indicator code (1-16)
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Sub-indicator code (comma separated for multiple values)
         - in: query
           name: state_code
-          schema: { type: integer }
-          description: State / UT code (1-36 states/UTs, 37=All India)
-        - in: query
-          name: gender_code
-          schema: { type: integer }
-          description: Gender code (1-3)
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: State / UT code (1-36 states/UTs, 37=All India; comma separated for multiple values)
         - in: query
           name: sector_code
-          schema: { type: integer }
-          description: Sector code (1-3)
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Sector code (1-3; comma separated for multiple values)
         - in: query
-          name: type_of_structure_code
-          schema: { type: integer }
-          description: Type of structure code (1-8)
-        - in: query
-          name: supplementary_source_of_drinking_water_code
-          schema: { type: integer }
-          description: Supplementary source of drinking water code (1-19)
-        - in: query
-          name: social_group_code
-          schema: { type: integer }
-          description: Social group code (1-5)
-        - in: query
-          name: dwelling_units_code
-          schema: { type: integer }
-          description: Dwelling units code (1-7)
-        - in: query
-          name: agency_emptied_code
-          schema: { type: integer }
-          description: Agency emptied code (1-7)
-        - in: query
-          name: distribution_by_plinth_level_code
-          schema: { type: integer }
-          description: Distribution by plinth level code (1-7)
-        - in: query
-          name: distribution_by_experience_of_flood_code
-          schema: { type: integer }
-          description: Distribution by experience of flood code (1-5)
-        - in: query
-          name: tenurial_status_code
-          schema: { type: integer }
-          description: Tenurial status code (1-4)
-        - in: query
-          name: principal_source_of_drinking_water_code
-          schema: { type: integer }
-          description: Principal source of drinking water code (1-20)
-        - in: query
-          name: households_percentage_code
-          schema: { type: integer }
-          description: Households percentage code (1-6)
-        - in: query
-          name: month_code
-          schema: { type: integer }
-          description: Month code (1-13)
-        - in: query
-          name: percentage_houses_number_floors_house_code
-          schema: { type: integer }
-          description: Percentage houses number floors house code (1-6)
-        - in: query
-          name: percentage_houses_separate_kitchen_code
-          schema: { type: integer }
-          description: Percentage houses separate kitchen code (1-3)
+          name: gender_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Gender code (1-3; comma separated for multiple values)
         - in: query
           name: quintile_class_code
-          schema: { type: integer }
-          description: Quintile class code (1-15)
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Quintile class code (1-15; comma separated for multiple values)
         - in: query
-          name: type_of_approach_road_code
-          schema: { type: integer }
-          description: Type of approach road code (1-5)
+          name: month_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Month code (1-13; comma separated for multiple values)
+
+        # --- Disability module filters (survey_code=1) ---
         - in: query
-          name: types_of_latrine_uses_code
-          schema: { type: integer }
-          description: Types of latrine uses code (1-6)
+          name: disability_type_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Type of disability code (1-8; comma separated for multiple values)
         - in: query
-          name: method_of_treatment_of_water_code
-          schema: { type: integer }
-          description: Method of treatment of water code (1-3)
+          name: treatment_taken_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Treatment taken code (1-10; comma separated for multiple values)
         - in: query
-          name: water_facility_code
-          schema: { type: integer }
-          description: Water facility code (1-3)
+          name: arrangement_of_caregiver_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Arrangement of caregiver code (1-4; comma separated for multiple values)
         - in: query
-          name: dwshhc_street_light_facility_water_facility_code
-          schema: { type: integer }
-          description: Dwshhc street light facility water facility code (1-2)
+          name: use_of_public_transport_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Use of public transport code (1-4; comma separated for multiple values)
         - in: query
           name: status_of_receipt_of_aid_help_code
-          schema: { type: integer }
-          description: Status of receipt of aid/help code (1-6)
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Status of receipt of aid/help code (1-6; comma separated for multiple values)
+
+        # --- Housing & drinking water module filters (survey_code=2) ---
+        - in: query
+          name: principal_source_of_drinking_water_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Principal source of drinking water code (1-20; comma separated for multiple values)
+        - in: query
+          name: supplementary_source_of_drinking_water_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Supplementary source of drinking water code (1-19; comma separated for multiple values)
+        - in: query
+          name: method_of_treatment_of_water_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Method of treatment of water code (1-3; comma separated for multiple values)
+        - in: query
+          name: households_percentage_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Households percentage code (1-6; comma separated for multiple values)
+        - in: query
+          name: number_of_days_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Number of days code (1-4; comma separated for multiple values)
+        - in: query
+          name: type_of_structure_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Type of structure code (1-8; comma separated for multiple values)
+        - in: query
+          name: material_category_type_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Material category type code (1-9; comma separated for multiple values)
+        - in: query
+          name: dwelling_units_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Dwelling units code (1-7; comma separated for multiple values)
+        - in: query
+          name: tenurial_status_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Tenurial status code (1-4; comma separated for multiple values)
+        - in: query
+          name: distribution_by_plinth_level_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Distribution by plinth level code (1-7; comma separated for multiple values)
+        - in: query
+          name: percentage_houses_number_floors_house_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Percentage houses number floors house code (1-6; comma separated for multiple values)
+        - in: query
+          name: percentage_houses_separate_kitchen_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Percentage houses separate kitchen code (1-3; comma separated for multiple values)
+        - in: query
+          name: type_of_approach_road_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Type of approach road code (1-5; comma separated for multiple values)
+        - in: query
+          name: types_of_latrine_uses_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Types of latrine uses code (1-6; comma separated for multiple values)
+        - in: query
+          name: agency_emptied_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Agency emptied code (1-7; comma separated for multiple values)
+        - in: query
+          name: distribution_by_experience_of_flood_code
+          schema:
+            type: string
+            pattern: ^\d+(,\d+)*$
+          description: Distribution by experience of flood code (1-5; comma separated for multiple values)
+
         - in: query
           name: limit
           schema: { type: integer, default: 20 }

--- a/swagger/swagger_user_nss76.yaml
+++ b/swagger/swagger_user_nss76.yaml
@@ -1,0 +1,186 @@
+openapi: 3.0.1
+info:
+  title: National Sample Survey (NSS 76th Round)
+  version: 1.0.0
+servers:
+- url: https://api.mospi.gov.in/
+tags:
+- name: NSS76
+  description: National Sample Survey 76th Round.
+paths:
+  /api/nss-76/getNss76Records:
+    get:
+      tags:
+      - NSS76
+      operationId: NSS76IndicatorValues.
+      description: |
+        - **Required:** `indicator_code`
+        - **Required in practice:** `survey_code` (1=Disability indicators 1-13, 2=Housing & drinking water indicators 14-26)
+        - **Filters (optional):** sub_indicator_code, state_code (37=All India), gender_code, sector_code, type_of_structure_code, supplementary_source_of_drinking_water_code, social_group_code, dwelling_units_code, agency_emptied_code, distribution_by_plinth_level_code, distribution_by_experience_of_flood_code, tenurial_status_code, principal_source_of_drinking_water_code, households_percentage_code, month_code, percentage_houses_number_floors_house_code, percentage_houses_separate_kitchen_code, quintile_class_code, type_of_approach_road_code, types_of_latrine_uses_code, method_of_treatment_of_water_code, water_facility_code, dwshhc_street_light_facility_water_facility_code, status_of_receipt_of_aid_help_code
+        - **Metadata/filters API (not in this path):** `/api/nss-76/getNSS76FilterByIndicatorId`
+        - **Indicators API (not in this path):** `/api/nss-76/getIndicatorList?survey_code=1|2`
+
+      parameters:
+        - in: query
+          name: indicator_code
+          required: true
+          schema: { type: integer }
+          description: Enter the indicator code (1-13 Disability module, 14-26 Housing & water module; code 17 unused)
+        - in: query
+          name: survey_code
+          schema: { type: string }
+          description: Survey module code (1=Disability, 2=Housing & drinking water)
+        - in: query
+          name: sub_indicator_code
+          schema: { type: integer }
+          description: Enter the sub-indicator code (1-16)
+        - in: query
+          name: state_code
+          schema: { type: integer }
+          description: State / UT code (1-36 states/UTs, 37=All India)
+        - in: query
+          name: gender_code
+          schema: { type: integer }
+          description: Gender code (1-3)
+        - in: query
+          name: sector_code
+          schema: { type: integer }
+          description: Sector code (1-3)
+        - in: query
+          name: type_of_structure_code
+          schema: { type: integer }
+          description: Type of structure code (1-8)
+        - in: query
+          name: supplementary_source_of_drinking_water_code
+          schema: { type: integer }
+          description: Supplementary source of drinking water code (1-19)
+        - in: query
+          name: social_group_code
+          schema: { type: integer }
+          description: Social group code (1-5)
+        - in: query
+          name: dwelling_units_code
+          schema: { type: integer }
+          description: Dwelling units code (1-7)
+        - in: query
+          name: agency_emptied_code
+          schema: { type: integer }
+          description: Agency emptied code (1-7)
+        - in: query
+          name: distribution_by_plinth_level_code
+          schema: { type: integer }
+          description: Distribution by plinth level code (1-7)
+        - in: query
+          name: distribution_by_experience_of_flood_code
+          schema: { type: integer }
+          description: Distribution by experience of flood code (1-5)
+        - in: query
+          name: tenurial_status_code
+          schema: { type: integer }
+          description: Tenurial status code (1-4)
+        - in: query
+          name: principal_source_of_drinking_water_code
+          schema: { type: integer }
+          description: Principal source of drinking water code (1-20)
+        - in: query
+          name: households_percentage_code
+          schema: { type: integer }
+          description: Households percentage code (1-6)
+        - in: query
+          name: month_code
+          schema: { type: integer }
+          description: Month code (1-13)
+        - in: query
+          name: percentage_houses_number_floors_house_code
+          schema: { type: integer }
+          description: Percentage houses number floors house code (1-6)
+        - in: query
+          name: percentage_houses_separate_kitchen_code
+          schema: { type: integer }
+          description: Percentage houses separate kitchen code (1-3)
+        - in: query
+          name: quintile_class_code
+          schema: { type: integer }
+          description: Quintile class code (1-15)
+        - in: query
+          name: type_of_approach_road_code
+          schema: { type: integer }
+          description: Type of approach road code (1-5)
+        - in: query
+          name: types_of_latrine_uses_code
+          schema: { type: integer }
+          description: Types of latrine uses code (1-6)
+        - in: query
+          name: method_of_treatment_of_water_code
+          schema: { type: integer }
+          description: Method of treatment of water code (1-3)
+        - in: query
+          name: water_facility_code
+          schema: { type: integer }
+          description: Water facility code (1-3)
+        - in: query
+          name: dwshhc_street_light_facility_water_facility_code
+          schema: { type: integer }
+          description: Dwshhc street light facility water facility code (1-2)
+        - in: query
+          name: status_of_receipt_of_aid_help_code
+          schema: { type: integer }
+          description: Status of receipt of aid/help code (1-6)
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+        - in: query
+          name: page
+          schema: { type: integer, minimum: 1 }
+        - in: query
+          name: format
+          schema:
+            type: string
+          description: Set to `xlsx` to download as Excel
+        - in: query
+          name: Format
+          schema:
+            type: string
+            default: JSON
+            enum:
+            - JSON
+            - CSV
+          description: Output format (JSON or CSV)
+
+      responses:
+        "200":
+          description: A JSON array of user information
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid request body
+            text/csv:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid request body
+      security:
+      - bearerAuth: []
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      description: Bearer token to access these api endpoints
+      name: Authorization
+      in: header
+x-original-swagger-version: "2.0"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,4 +1,4 @@
-"""MCP Server health-check tests — all 4 tools across all 23 datasets.
+"""MCP Server health-check tests — all 4 tools across all 24 datasets.
 
 Uses FastMCP Client (in-process by default, HTTP via MCP_SERVER_URL env var).
 Run:  pytest tests/ -v
@@ -186,6 +186,12 @@ DATASETS = [
         id="MNRE",
     ),
     pytest.param(
+        "NSS76",
+        {"indicator_code": 1},
+        {"indicator_code": "1", "survey_code": "1", "state_code": "1", "limit": "1"},
+        id="NSS76",
+    ),
+    pytest.param(
         "NSS80",
         {"indicator_code": 1},
         {"indicator_code": "1", "limit": "1"},
@@ -203,7 +209,7 @@ EXPECTED_TOOLS = {
 EXPECTED_DATASETS = {
     "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
-    "NSS77", "NSS78", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80",
+    "NSS77", "NSS78", "NSS76", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80",
 }
 
 # Internal keys injected by the server (not dataset-specific content)
@@ -229,7 +235,7 @@ async def test_list_tools(mcp_target):
 
 
 async def test_list_datasets(mcp_target):
-    """list_datasets: API overview returns all 23 datasets and workflow instructions."""
+    """list_datasets: API overview returns all 24 datasets and workflow instructions."""
     data = await call(mcp_target, "list_datasets", {})
     assert isinstance(data, dict)
     assert "datasets" in data


### PR DESCRIPTION
Follow-up to the NSS76 dataset addition. Corrects the filter parameter schema in `swagger/swagger_user_nss76.yaml`, verified against the live MoSPI API (filter dimensions across all 26 indicators + data-endpoint behavior).

## Changes

- **Add 6 filter params** the data API exposes and honors but the swagger omitted, so `validate_filters` was rejecting them through `get_data`:
  - Disability module: `disability_type_code`, `treatment_taken_code`, `arrangement_of_caregiver_code`, `use_of_public_transport_code`
  - Housing & water module: `number_of_days_code`, `material_category_type_code`
- **Remove 3 params** that are not real filter dimensions for any indicator and silently zero out results when applied (the API returns 0 rows for every value, vs ignoring unknown params): `social_group_code`, `water_facility_code`, `dwshhc_street_light_facility_water_facility_code`.
- **Switch filter `*_code` params** from `integer` to `string` with the `^\d+(,\d+)*$` multi-value pattern, matching NSS80 and the documented project convention. The API accepts comma-separated values (e.g. `state_code=1,2,3`); this was previously hidden from callers.

The swagger now documents exactly the 27 filter dimensions the live filter API advertises.

## Verification

- End-to-end via the MCP `get_data` tool: a newly added filter (`disability_type_code=1` → 9 rows) and multi-value (`state_code=1,3,5` → 27 rows across 3 states) both work.
- NSS76 test suite passes (`get_indicators`, `get_metadata`, `get_data`).