### PR TITLE
feat: add NSS75E dataset (Education / Social Consumption on Education)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- NSS75E (NSS 75th Round - Education / Social Consumption on Education) with 13 indicators (survey_code=2, codes 43-55): literacy rate, educational attainment, mean years of schooling, GAR/NAR, student attendance and course-type distribution, average student expenditure by course and expenditure item, and household computer/internet access. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-75/getNSS75FilterByIndicatorId`.
 - NSS76 (NSS 76th Round - Disability + Housing & Drinking Water) with 25 indicators across two modules: survey_code=1 (Disability, indicators 1-13) covering disability prevalence, literacy, education, employment, care arrangements, and receipt of aid/help; survey_code=2 (Housing & drinking water, indicators 14-26) covering drinking water sources, sufficiency, treatment, housing characteristics, latrines, and flood experience. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-76/getNSS76FilterByIndicatorId` (swagger documents data endpoint only).
 
 ### Changed
-- Total datasets: 23 → 24
-- list_datasets, get_indicators, and get_metadata updated to include NSS76
+- Total datasets: 23 → 25 (NSS76, NSS75E)
+- list_datasets, get_indicators, and get_metadata updated to include NSS76 and NSS75E
 - Upgraded fastmcp from 3.0.0b1 to 3.3.1, moving from a beta to a stable release. The mcp SDK is now resolved transitively by fastmcp and is no longer pinned in requirements.txt.
 - serverInfo now reports an explicit application version instead of the underlying framework version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Adding a New Dataset
 
-The server currently supports 24 datasets. To add a new one:
+The server currently supports 25 datasets. To add a new one:
 
 ### 1. Get the Swagger spec
 
@@ -111,7 +111,7 @@ pip install -r tests/requirements-test.txt
 pytest tests/ -v -p no:anyio
 ```
 
-This runs tests covering all 24 datasets across all 4 tools, plus negative/error-path tests. Tests hit the live MoSPI API with a 0.5s throttle between calls to avoid rate-limiting.
+This runs tests covering all 25 datasets across all 4 tools, plus negative/error-path tests. Tests hit the live MoSPI API with a 0.5s throttle between calls to avoid rate-limiting.
 
 To test against a deployed server instead of in-process:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ MCP (Model Context Protocol) server for accessing India's Ministry of Statistics
 This server provides AI-ready access to official Indian government statistics through the Model Context Protocol (MCP). It acts as a bridge between AI assistants (Claude, ChatGPT, Cursor, etc.) and MoSPI's open data APIs, enabling natural language queries for economic, demographic, and social indicators.
 
 **Key Features:**
-- 24 statistical datasets covering employment, inflation, industrial production, GDP, energy, renewable energy, higher education, school education, gender, health, disability, housing, environment, trade, agriculture, consumption, economic census, and digital literacy
+- 25 statistical datasets covering employment, inflation, industrial production, GDP, energy, renewable energy, higher education, school education, gender, health, disability, housing, NSS education consumption, environment, trade, agriculture, consumption, economic census, and digital literacy
 - Sequential 4-tool workflow designed for LLM consumption
 - Swagger-driven parameter validation
 - Full OpenTelemetry integration for observability
@@ -82,6 +82,7 @@ This server provides AI-ready access to official Indian government statistics th
 | **UDISE** | UDISE+ (Unified District Information System for Education) | Schools, enrolment, dropout rates, teachers, PTR, GER, NER, GPI, CWSN, school infrastructure, ICT labs, minority enrolment |
 | **MNRE** | Renewable Energy (Ministry of New and Renewable Energy) | State-wise monthly installed capacity (MW) for solar, wind, hydro, bio, and total renewable power |
 | **NSS76** | NSS 76th Round (Disability + Housing & Drinking Water) | Disability prevalence, literacy and education among PwD, care arrangements, aid/help, drinking water sources, water treatment, housing characteristics, latrines, flood experience |
+| **NSS75E** | NSS 75th Round (Education / Social Consumption on Education) | Literacy rate, educational attainment, GAR/NAR, student attendance, course-type distribution, education expenditure, household computer and internet access |
 | **NSS80** | NSS 80th Round (Telecom (CMST) + Education (CMSE)) | Mobile phone ownership, internet usage, online banking, cybercrime, household telecom connectivity, school enrolment and expenditure course fees, private coaching | 
 <!-- | NMKN | National Namkeen Consumption Index | Bhujia per capita, sev consumption patterns, mixture preference by state | -->
 
@@ -265,7 +266,7 @@ mospi-mcp-api/
 │   └── swagger_user_*.yaml
 ├── observability/
 │   └── telemetry.py         # OpenTelemetry middleware for tracing
-├── tests/                   # Pytest suite (covering all 24 datasets)
+├── tests/                   # Pytest suite (covering all 25 datasets)
 ├── Dockerfile               # Production container with OTEL instrumentation
 ├── docker-compose.yml       # Full stack with Jaeger
 └── requirements.txt
@@ -289,7 +290,7 @@ pip install -r tests/requirements-test.txt
 pytest tests/ -v -p no:anyio
 ```
 
-Runs in-process against the MCP server (no running server needed). Covers all 24 datasets across all 4 tools. See [CONTRIBUTING.md](CONTRIBUTING.md#testing) for details.
+Runs in-process against the MCP server (no running server needed). Covers all 25 datasets across all 4 tools. See [CONTRIBUTING.md](CONTRIBUTING.md#testing) for details.
 
 ---
 

--- a/definitions/nss75e_definitions.json
+++ b/definitions/nss75e_definitions.json
@@ -1,0 +1,67 @@
+[
+  {
+    "indicator_code": 43,
+    "name": "Literacy rate (in per cent) among persons of age 7 years and above for different States",
+    "description": "Literacy rate (in per cent) among persons of age 7 years and above for different States"
+  },
+  {
+    "indicator_code": 44,
+    "name": "Percentage distribution of persons of age 15 years and above by highest level of education successfully completed for different States",
+    "description": "Percentage distribution of persons of age 15 years and above by highest level of education successfully completed for different States"
+  },
+  {
+    "indicator_code": 45,
+    "name": "Average number of years completed in formal education among persons of age 15 years and above for different States",
+    "description": "Average number of years completed in formal education among persons of age 15 years and above for different States"
+  },
+  {
+    "indicator_code": 46,
+    "name": "Average number of years completed in formal education among persons of age 25 years and above for different States",
+    "description": "Average number of years completed in formal education among persons of age 25 years and above for different States"
+  },
+  {
+    "indicator_code": 47,
+    "name": "Percentage distribution of students (persons of age 3 to 35 years currently attending education) by level of current attendance for different States",
+    "description": "Percentage distribution of students (persons of age 3 to 35 years currently attending education) by level of current attendance for different States"
+  },
+  {
+    "indicator_code": 48,
+    "name": "Gross Attendance Ratio (GAR) at different levels of education for different States",
+    "description": "Gross Attendance Ratio (GAR) at different levels of education for different States"
+  },
+  {
+    "indicator_code": 49,
+    "name": "Net Attendance Ratio (NAR) at different levels of education for different States",
+    "description": "Net Attendance Ratio (NAR) at different levels of education for different States"
+  },
+  {
+    "indicator_code": 50,
+    "name": "Percentage distribution of students by type of course pursuing (general course and technical/ professional course) for different States",
+    "description": "Percentage distribution of students by type of course pursuing (general course and technical/ professional course) for different States"
+  },
+  {
+    "indicator_code": 51,
+    "name": "Average expenditure (Rs.) per student in basic course in the current academic year by type of course pursuing (general course and technical/ professional course) for different States",
+    "description": "Average expenditure (Rs.) per student in basic course in the current academic year by type of course pursuing (general course and technical/ professional course) for different States"
+  },
+  {
+    "indicator_code": 52,
+    "name": "Average expenditure (Rs.) on basic course per student during current academic year pursuing general course by items of expenditure for different States.",
+    "description": "Average expenditure (Rs.) on basic course per student during current academic year pursuing general course by items of expenditure for different States."
+  },
+  {
+    "indicator_code": 53,
+    "name": "Average expenditure (Rs.) on basic course per student during current academic year pursuing technical/professional course by items of expenditure for different States",
+    "description": "Average expenditure (Rs.) on basic course per student during current academic year pursuing technical/professional course by items of expenditure for different States"
+  },
+  {
+    "indicator_code": 54,
+    "name": "Average expenditure (Rs.) on basic course per student during current academic year any course by items of expenditure for different States",
+    "description": "Average expenditure (Rs.) on basic course per student during current academic year any course by items of expenditure for different States"
+  },
+  {
+    "indicator_code": 55,
+    "name": "Percentage of households with computer and internet facility for different States",
+    "description": "Percentage of households with computer and internet facility for different States"
+  }
+]

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -83,6 +83,7 @@ class MoSPI:
             "NSS79": "/api/nss-79/getNSS79Records",
             "NSS80": "/api/nss-80/getNSS80Records",
             "NSS76": "/api/nss-76/getNss76Records",
+            "NSS75E": "/api/nss-75/getNSS75Records",
             "CPIALRL": "/api/cpialrl/getCpialrlRecords",
             "HCES": "/api/hces/getHcesRecords",
             "TUS": "/api/tus/getTusRecords",
@@ -985,6 +986,75 @@ class MoSPI:
         try:
             response = self.session.get(
                 f"{self.base_url}/api/nss-76/getNSS76FilterByIndicatorId",
+                params=params,
+                timeout=30,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    # =========================================================================
+    # NSS75E (NSS 75th Round - Education / Social Consumption on Education) Methods
+    # =========================================================================
+    @staticmethod
+    def _nss75e_survey_for(indicator_code: int) -> Optional[int]:
+        """
+        Map NSS75E indicator_code to survey_code.
+
+        Education module (survey_code=2): indicators 43-55.
+        """
+        if 43 <= indicator_code <= 55:
+            return 2
+        return None
+
+    def get_nss75e_indicators(self) -> Dict[str, Any]:
+        """Fetch list of NSS75E indicators from MoSPI API.
+
+        Returns 13 education indicators from NSS 75th Round (survey_code=2):
+        literacy, educational attainment, attendance ratios (GAR/NAR),
+        course type distribution, student expenditure, and household digital access.
+        """
+        try:
+            response = self.session.get(
+                f"{self.base_url}/api/nss-75/getIndicatorList",
+                params={"survey_code": 2},
+                timeout=30,
+            )
+            response.raise_for_status()
+            result = response.json()
+            result["count"] = len(result.get("data", []))
+            result["_note"] = (
+                "survey_code=2 (Education module): indicators 43-55. "
+                "Pass survey_code in get_metadata/get_data or rely on auto-derivation."
+            )
+            return result
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    def get_nss75e_filters(self, indicator_code: int, survey_code: Optional[int] = None) -> Dict[str, Any]:
+        """Fetch available NSS75E filters for given indicator.
+
+        Args:
+            indicator_code: Indicator code (43-55).
+            survey_code: Education module code (always 2). Auto-derived if omitted.
+        """
+        if survey_code is None:
+            survey_code = self._nss75e_survey_for(indicator_code)
+            if survey_code is None:
+                return {
+                    "error": (
+                        f"Invalid indicator_code {indicator_code}. "
+                        "Valid range for NSS75E: 43-55 (Education module)."
+                    ),
+                    "statusCode": False,
+                }
+
+        params = {"indicator_code": indicator_code, "survey_code": survey_code}
+
+        try:
+            response = self.session.get(
+                f"{self.base_url}/api/nss-75/getNSS75FilterByIndicatorId",
                 params=params,
                 timeout=30,
             )

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -35,7 +35,7 @@ def enrich_indicators(result: Dict[str, Any], dataset: str) -> Dict[str, Any]:
     """Enrich indicator list with definitions from definitions/ folder.
 
     Handles all response structures:
-    - result["data"] = flat list  (AISHE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS76, HCES, TUS, EC)
+    - result["data"] = flat list  (AISHE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS76, NSS75E, HCES, TUS, EC)
     - result["indicators_by_frequency"] = dict of lists  (PLFS, ASUSE)
     - result["data"]["indicator"] = list  (NAS, ENERGY, CPIALRL)
     - result["indicator"] = list  (NSS78)
@@ -80,7 +80,7 @@ mcp.add_middleware(TelemetryMiddleware())
 VALID_DATASETS = [
     "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
-    "NSS77", "NSS78", "NSS76", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
+    "NSS77", "NSS78", "NSS76", "NSS75E", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
 ]
 
 # Maps dataset key -> (swagger_yaml_file, endpoint_path)
@@ -112,12 +112,13 @@ DATASET_SWAGGER = {
     "MNRE": ("swagger_user_mnre.yaml", "/api/mnre/getDataByEnergy"),
     "NSS80": ("swagger_user_nss80.yaml", "/api/nss-80/getNSS80Records"),
     "NSS76": ("swagger_user_nss76.yaml", "/api/nss-76/getNss76Records"),
+    "NSS75E": ("swagger_user_nss75e.yaml", "/api/nss-75/getNSS75Records"),
 }
 
 # Datasets that require indicator_code in get_data
 DATASETS_REQUIRING_INDICATOR = [
     "PLFS", "NAS", "ENERGY", "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS",
-    "NSS77", "NSS78", "NSS76", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
+    "NSS77", "NSS78", "NSS76", "NSS75E", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
 ]
 
 
@@ -255,7 +256,7 @@ def get_indicators(
     Args:
         dataset: Dataset name — one of: PLFS, CPI, IIP, ASI, NAS, WPI,
                  ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI,
-                 NSS77, NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
+                 NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
                  For CPI, IIP, WPI: returns available base years and frequencies.
         user_query: The user's original question. Captured for telemetry analytics; not echoed back in the response.
 
@@ -290,6 +291,7 @@ def get_indicators(
         "UDISE": mospi.get_udise_indicators,
         "MNRE": mospi.get_mnre_indicators,
         "NSS76": mospi.get_nss76_indicators,
+        "NSS75E": mospi.get_nss75e_indicators,
         "NSS80": mospi.get_nss80_indicators,
         # Special datasets - return guidance instead of indicators
         "CPI": mospi.get_cpi_base_years,
@@ -345,7 +347,7 @@ def get_metadata(
     Args:
         dataset: Dataset name (same values as get_indicators).
         indicator_code: Required for: PLFS, NAS, ENERGY, AISHE, ASUSE, GENDER,
-                        NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
+                        NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
                         Not applicable for: CPI, IIP, ASI, WPI.
                         For RBI, this maps to sub_indicator_code internally.
         frequency_code: Required for PLFS and ASUSE.
@@ -361,8 +363,8 @@ def get_metadata(
         classification_year: Required for ASI ("2008"/"2004"/"1998"/"1987").
         series: For CPI and NAS only ("Current"/"Back").
         use_of_energy_balance_code: For ENERGY only (1=Supply, 2=Consumption).
-        survey_code: For NSS76 (1=Disability, 2=Housing & drinking water) and NSS80
-                     (1=Telecom (CMST), 2=Education (CMSE)).
+        survey_code: For NSS76 (1=Disability, 2=Housing & drinking water), NSS75E
+                     (2=Education, indicators 43-55), and NSS80 (1=Telecom (CMST), 2=Education (CMSE)).
 
     Returns:
         dict with 'filter_values' (valid codes for each parameter),
@@ -632,6 +634,22 @@ def get_metadata(
             result["next_step"] = _next
             return _check_empty_metadata(result, dataset, indicator_code=indicator_code, survey_code=survey_code)
 
+        elif dataset == "NSS75E":
+            if indicator_code is None:
+                return {"error": "indicator_code is required for NSS75E. Education module indicators 43-55."}
+            survey_code, err = _safe_int(survey_code, "survey_code")
+            if err:
+                return err
+            result = mospi.get_nss75e_filters(indicator_code=indicator_code, survey_code=survey_code)
+            result["api_params"] = get_swagger_param_definitions("NSS75E")
+            result["parameter_notes"] = (
+                "survey_code is required by the data API (always 2 for NSS75E Education module). "
+                "Auto-derived from indicator_code (43-55) if omitted. "
+                "Filter keys use id/label (e.g. state, gender, sector)."
+            )
+            result["next_step"] = _next
+            return _check_empty_metadata(result, dataset, indicator_code=indicator_code, survey_code=survey_code)
+
         elif dataset == "NSS80":
             if indicator_code is None:
                 return {"error": "indicator_code is required for NSS80. CMST=1-20, CMSE=23-42."}
@@ -673,7 +691,7 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     Args:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY,
                  AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77,
-                 NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80).
+                 NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80).
                  CPI auto-routes to Group or Item endpoint based on
                  whether filters contain item_code.
                  IIP uses a single endpoint; pass frequency="Annually" or
@@ -729,6 +747,7 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
         "UDISE": "UDISE",
         "MNRE": "MNRE",
         "NSS76": "NSS76",
+        "NSS75E": "NSS75E",
         "NSS80": "NSS80",
     }
 
@@ -765,6 +784,17 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
             try:
                 ic_int = int(str(ic).split(",")[0])
                 derived = mospi._nss80_survey_for(ic_int)
+                if derived is not None:
+                    transformed_filters["survey_code"] = str(derived)
+            except (ValueError, AttributeError):
+                pass
+
+    if dataset == "NSS75E" and "survey_code" not in transformed_filters:
+        ic = transformed_filters.get("indicator_code")
+        if ic is not None:
+            try:
+                ic_int = int(str(ic).split(",")[0])
+                derived = mospi._nss75e_survey_for(ic_int)
                 if derived is not None:
                     transformed_filters["survey_code"] = str(derived)
             except (ValueError, AttributeError):
@@ -829,7 +859,7 @@ def list_datasets() -> dict:
         and 'workflow' (the four-step sequence).
     """
     return {
-        "total_datasets": 24,
+        "total_datasets": 25,
         "datasets": {
             "PLFS": {
                 "name": "Periodic Labour Force Survey",
@@ -941,6 +971,11 @@ def list_datasets() -> dict:
                 "description": "5 indicators on state-wise monthly installed renewable energy capacity (MW): 1=Solar Power (5 categories: ground-mounted, rooftop, hybrid, off-grid/KUSUM, total), 2=Wind Power (no categories), 3=Hydro Power (small, large), 4=Bio Power (waste-to-energy, biomass cogeneration, bagasse, off-grid, total), 5=Total Power (aggregate of all renewables). Coverage from 2020 onwards, 36 states/UTs plus All India, monthly granularity.",
                 "use_for": "Renewable energy capacity, solar power installed capacity, wind power, hydro power, bio power, rooftop solar, KUSUM, biomass, state-wise renewable energy, MNRE statistics, clean energy, green energy capacity"
             },
+            "NSS75E": {
+                "name": "NSS75E (75th Round - Education / Social Consumption on Education)",
+                "description": "13 indicators from NSS 75th Round Education module (survey_code=2, indicators 43-55): literacy rate, educational attainment, mean years of schooling, student attendance distribution, Gross and Net Attendance Ratios (GAR/NAR), course-type distribution, average student expenditure on basic courses (general and technical/professional, by expenditure item), and household computer/internet access.",
+                "use_for": "Literacy rate, educational attainment, years of schooling, GAR, NAR, student attendance, education expenditure, general vs technical courses, household internet and computer access, NSS 75th round education"
+            },
             "NSS76": {
                 "name": "NSS76 (76th Round - Disability + Housing & Drinking Water)",
                 "description": "25 indicators from NSS 76th Round in two modules. Disability module (survey_code=1, indicators 1-13): prevalence of disability, literacy and education among persons with disability, employment, care arrangements, and receipt of aid/help by state/UT. Housing & water module (survey_code=2, indicators 14-26): principal and supplementary sources of drinking water, sufficiency of supply, treatment methods, housing characteristics (floor area, living rooms, plinth level, approach road, separate kitchen, floors), latrine use, and flood experience.",
@@ -969,7 +1004,7 @@ if __name__ == "__main__":
     log("="*75)
     log("Serving Indian Government Statistical Data")
     log("Framework: FastMCP 3.3 with OpenTelemetry")
-    log("Datasets: 24 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80)")
+    log("Datasets: 25 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80)")
     log("Server: http://localhost:8000/mcp")
     log("Telemetry: IP tracking + Input/Output capture enabled")
     log("="*75 + "\n")

--- a/swagger/swagger_user_nss75e.yaml
+++ b/swagger/swagger_user_nss75e.yaml
@@ -1,0 +1,128 @@
+openapi: 3.0.1
+info:
+  title: NSS 75th Round - Education (NSS75E / Social Consumption on Education)
+  version: 1.0.0
+servers:
+- url: https://api.mospi.gov.in/
+tags:
+- name: NSS75E
+  description: NSS 75th Round — All India Survey on Household Social Consumption on Education.
+paths:
+  /api/nss-75/getNSS75Records:
+    get:
+      tags:
+      - NSS75E
+      operationId: NSS75EIndicatorValues
+      description: |
+        - **Required:** `survey_code` (must be 2 for Education module), `indicator_code` (43-55)
+        - **Filters (optional):** state_code, sector_code, gender_code, type_of_course_code, item_of_expenditure_code, facility_code, highest_level_of_education_successfully_completed_code, level_of_education_code, level_of_current_attendance_code
+        - **Metadata/filters API (not in this path):** `/api/nss-75/getNSS75FilterByIndicatorId`
+        - **Indicators API (not in this path):** `/api/nss-75/getIndicatorList?survey_code=2`
+
+      parameters:
+        - in: query
+          name: survey_code
+          required: true
+          schema: { type: integer, enum: [2] }
+          description: Education module code (always 2 for NSS75E indicators 43-55)
+
+        - in: query
+          name: indicator_code
+          required: true
+          schema: { type: integer }
+          description: Indicator code (43-55)
+
+        - in: query
+          name: state_code
+          schema: { type: integer }
+          description: State / UT code (1-36 states/UTs; use get_metadata for valid values)
+
+        - in: query
+          name: sector_code
+          schema: { type: integer }
+          description: Sector code (1-4)
+
+        - in: query
+          name: gender_code
+          schema: { type: integer }
+          description: Gender code (1-7)
+
+        - in: query
+          name: type_of_course_code
+          schema: { type: integer }
+          description: Course type code (1-4)
+
+        - in: query
+          name: item_of_expenditure_code
+          schema: { type: integer }
+          description: Expenditure item code (1-6)
+
+        - in: query
+          name: facility_code
+          schema: { type: integer }
+          description: Facility type code (1-2)
+
+        - in: query
+          name: highest_level_of_education_successfully_completed_code
+          schema: { type: integer }
+          description: Highest level of education successfully completed code (1-7)
+
+        - in: query
+          name: level_of_education_code
+          schema: { type: integer }
+          description: Level of education code (1-6)
+
+        - in: query
+          name: level_of_current_attendance_code
+          schema: { type: integer }
+          description: Level of current attendance code (1-8)
+
+        - in: query
+          name: limit
+          schema: { type: integer, default: 20 }
+
+        - in: query
+          name: page
+          schema: { type: integer, minimum: 1 }
+
+        - in: query
+          name: Format
+          schema:
+            type: string
+            enum: [JSON, CSV]
+            default: JSON
+          description: Response format (JSON or CSV)
+
+        - in: query
+          name: format
+          schema:
+            type: string
+          description: Set to `xlsx` to download as Excel
+
+      responses:
+        "200":
+          description: JSON array of indicator values
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Invalid request body
+      security:
+      - bearerAuth: []
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      description: Bearer token to access these api endpoints
+      name: Authorization
+      in: header
+x-original-swagger-version: "2.0"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,4 +1,4 @@
-"""MCP Server health-check tests — all 4 tools across all 24 datasets.
+"""MCP Server health-check tests — all 4 tools across all 25 datasets.
 
 Uses FastMCP Client (in-process by default, HTTP via MCP_SERVER_URL env var).
 Run:  pytest tests/ -v
@@ -192,6 +192,12 @@ DATASETS = [
         id="NSS76",
     ),
     pytest.param(
+        "NSS75E",
+        {"indicator_code": 43},
+        {"indicator_code": "43", "survey_code": "2", "state_code": "1", "limit": "1"},
+        id="NSS75E",
+    ),
+    pytest.param(
         "NSS80",
         {"indicator_code": 1},
         {"indicator_code": "1", "limit": "1"},
@@ -209,7 +215,7 @@ EXPECTED_TOOLS = {
 EXPECTED_DATASETS = {
     "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
-    "NSS77", "NSS78", "NSS76", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80",
+    "NSS77", "NSS78", "NSS76", "NSS75E", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80",
 }
 
 # Internal keys injected by the server (not dataset-specific content)
@@ -235,7 +241,7 @@ async def test_list_tools(mcp_target):
 
 
 async def test_list_datasets(mcp_target):
-    """list_datasets: API overview returns all 24 datasets and workflow instructions."""
+    """list_datasets: API overview returns all 25 datasets and workflow instructions."""
     data = await call(mcp_target, "list_datasets", {})
     assert isinstance(data, dict)
     assert "datasets" in data


### PR DESCRIPTION
## Summary
- Adds NSS 75th Round Education module (NSS75E) with 13 indicators (survey_code=2, codes 43-55).
- Wires all four MCP tools, swagger spec, definitions JSON, tests, and docs (25 datasets total).

## Test plan
- [x] pytest tests/ -v -p no:anyio (94 passed locally)
- [ ] Review PR CI (GitHub Actions)
- [ ] After merge: ssh ubun@10.24.89.20 './deploy.sh'.