### PR TITLE
feat: update NAS swagger and docs for account_code and base_year rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NSS76 (NSS 76th Round - Disability + Housing & Drinking Water) with 25 indicators across two modules: survey_code=1 (Disability, indicators 1-13) covering disability prevalence, literacy, education, employment, care arrangements, and receipt of aid/help; survey_code=2 (Housing & drinking water, indicators 14-26) covering drinking water sources, sufficiency, treatment, housing characteristics, latrines, and flood experience. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-76/getNSS76FilterByIndicatorId` (swagger documents data endpoint only).
 
 ### Changed
+- NAS swagger updated from portal (v1.0.11): `account_code` filter (01-02), comma-separated `indicator_code`, clarified base_year/series rules (2011-12 → Current+Back; 2022-23 → Current only).
 - Total datasets: 23 → 25 (NSS76, NSS75E)
 - list_datasets, get_indicators, and get_metadata updated to include NSS76 and NSS75E
 - Upgraded fastmcp from 3.0.0b1 to 3.3.1, moving from a beta to a stable release. The mcp SDK is now resolved transitively by fastmcp and is no longer pinned in requirements.txt.

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -392,9 +392,10 @@ class MoSPI:
                 ]
             result["_note"] = (
                 "NAS requires base_year in get_metadata and get_data. "
-                "Available base years: '2022-23' (latest) and '2011-12'. "
-                "Latest base_year is '2022-23'. "
-                "Pass base_year along with series, frequency_code, and indicator_code."
+                "Available base years: '2022-23' (latest, Current series only) and '2011-12' (Current and Back series). "
+                "indicator_code accepts comma-separated values (1-22). "
+                "account_code (01-02) applies to indicators that expose account dimensions. "
+                "get_data frequency_code: 'Annually' or 'Quarterly' (filter API uses 1=Annually, 2=Quarterly)."
             )
             return result
         except requests.RequestException as e:

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -461,6 +461,13 @@ def get_metadata(
                 return {"error": "indicator_code is required for NAS"}
             result = mospi.get_nas_filters(series=series or "Current", frequency_code=frequency_code or 1, indicator_code=indicator_code, base_year=base_year or "2022-23")
             result["api_params"] = get_swagger_param_definitions("NAS")
+            result["parameter_notes"] = (
+                "base_year='2011-12' supports series Current and Back; base_year='2022-23' supports Current only. "
+                "indicator_code accepts comma-separated values in get_data (1-22). "
+                "New filter: account_code (01-02) for applicable indicators. "
+                "Filter metadata API uses frequency_code 1=Annually, 2=Quarterly; "
+                "get_data accepts 'Annually'/'Quarterly' (or 1/2)."
+            )
             result["next_step"] = _next
             return _check_empty_metadata(result, dataset, indicator_code=indicator_code, base_year=base_year, frequency_code=frequency_code)
 
@@ -883,7 +890,7 @@ def list_datasets() -> dict:
             },
             "NAS": {
                 "name": "National Accounts Statistics",
-                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. Both Current and Back series available. Requires base_year ('2022-23' latest, or '2011-12').",
+                "description": "22 annual + 11 quarterly indicators covering macroeconomic aggregates: GDP and GVA (production approach), consumption (private/government), capital formation (fixed, change in stock, valuables), trade (exports/imports), national income (GNI, disposable income), savings, and growth rates. base_year='2011-12' supports Current and Back series; base_year='2022-23' supports Current only. indicator_code accepts comma-separated values. account_code (01-02) filter added for applicable indicators.",
                 "use_for": "GDP, economic growth, national income, sectoral contribution, macro analysis"
             },
             "WPI": {

--- a/swagger/swagger_user_nas.yaml
+++ b/swagger/swagger_user_nas.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.1
 info:
   title: National Accounts Statistics (NAS)
+
   version: 1.0.11
 servers:
 - url: https://api.mospi.gov.in/
@@ -8,6 +9,7 @@ tags:
 - name: National Accounts Statistics.
   description: Indicator-wise National Accounts Statistics (NAS).
 paths:
+
   /api/nas/getNASData:
     get:
       tags:
@@ -17,97 +19,91 @@ paths:
       - name: base_year
         required: true
         in: query
-        description: Base year for constant price calculations
+        description: Select the Base Year (2011-12 supports Current & Back series, 2022-23 supports Current only)
         schema:
           type: string
           default: "2022-23"
           enum:
-          - "2022-23"
-          - "2011-12"
+            - "2022-23"
+            - "2011-12"
       - name: series
         required: true
         in: query
+        description: |
+          Select the Series type.
+          - If base_year = 2011-12 → Allowed values: Current, Back
+          - If base_year = 2022-23 → Allowed value: Current only
         schema:
-          default: Current
+          type: string
+          default: "Current"
           enum:
-          - Current
-          - Back
+            - "Current"
+            - "Back"
       - name: frequency_code
         required: true
         in: query
         schema:
-          default: Annually
+          default: "Annually"
           enum:
-          - Annually
-          - Quarterly
+          - "Annually"
+          - "Quarterly"
       - name: indicator_code
         required: true
         in: query
-        description: Enter the Indicator code (from 1 to 22, single value only)
+        description: Enter the Indicator code
+        #  (from 1 to 22. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+$
       - name: quarterly_code
         in: query
-        description: Enter the Quarterly code (from 1 to 4. Comma separated for multiple
-          values)
+        description: Enter the Quarterly code (from 1 to 4. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: year
         in: query
-        description: Enter the Year (format YYYY-YY. Comma separated for multiple
-          values)
+        description: Enter the Year (format YYYY-YY. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d{4}-\d{2}(,\d{4}-\d{2})*$
       - name: approach_code
         in: query
-        description: Enter the Approach code (from 01 to 03. Comma separated for multiple
-          values)
+        description: Enter the Approach code (from 01 to 03. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: revision_code
         in: query
-        description: Enter the Revision code (from 01 to 07. Comma separated for multiple
-          values)
+        description: Enter the Revision code (from 01 to 07. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
+      - name: account_code
+        in: query
+        description: Enter the Account code (from 01 to 02. Comma separated for multiple values)
+        schema:
+          type: string
       - name: institutional_code
         in: query
-        description: Enter the Institutional code (from 01 to 11. Comma separated
-          for multiple values)
+        description: Enter the Institutional code (from 01 to 11. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: industry_code
         in: query
-        description: Enter the Industry code (from 01 to 17. Comma separated for multiple
-          values)
+        description: Enter the Industry code (from 01 to 17. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: subindustry_code
         in: query
-        description: Enter the Subindustry code (from 01 to 18. Comma separated for
-          multiple values)
+        description: Enter the Subindustry code (from 01 to 18. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: limit
         in: query
         description: Number of records per page (default 10)
         schema:
           type: integer
-          pattern: ^\d+$
       - name: page
         in: query
         description: Enter the page no. (from 1 to n.)
         schema:
           type: string
-          pattern: ^\d+$
       - name: Format
         required: true
         in: query
@@ -119,9 +115,9 @@ paths:
           - JSON
           - CSV
       responses:
-        '200':
+        "200":
           description: A JSON array of user information
-        '400':
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -144,7 +140,8 @@ paths:
                   message:
                     type: string
                     example: Invalid request body
-        '409':
+      
+        "409":
           description: Not Found
           content:
             application/json:
@@ -159,6 +156,7 @@ paths:
                     example: Requested item wasn't found!
       security:
       - bearerAuth: []
+ 
 components:
   securitySchemes:
     bearerAuth:
@@ -166,4 +164,4 @@ components:
       description: Bearer token to access these api endpoints
       name: Authorization
       in: header
-x-original-swagger-version: '2.0'
+x-original-swagger-version: "2.0"


### PR DESCRIPTION
## Summary
- Merges portal **nss77a** (AIDIS — All India Debt & Investment Survey) into existing **NSS77** MCP dataset
- Single dataset remains `NSS77` — total datasets stay at **25** (no new dataset added)
- **55 indicators** total: 33 Land & Livestock + 22 AIDIS
- Module routing via `module=land_livestock` or `module=aidis` (required for overlapping codes: 16–19, 24, 26, 29, 32, 34, 36)

## Changes
- `mospi/client.py` — dual-module indicators, filters, and data routing (`getNss77AidisRecords`, limit 20–100)
- `mospi_server.py` — `module` param in get_metadata, swagger merge for AIDIS `$ref` params
- `swagger/swagger_user_nss77.yaml` — updated Land & Livestock spec
- `swagger/swagger_user_nss77_aidis.yaml` — official AIDIS swagger (from portal)
- `definitions/nss77_aidis_definitions.json` — AIDIS indicator definitions
- `tests/test_mcp_server.py` — NSS77 test uses indicator 21 (non-overlapping code)

## Test plan
- [x] `pytest tests/test_mcp_server.py` — 84/84 passed locally
- [ ] After merge: `./deploy.sh` on production VM
- [ ] Verify `get_indicators("NSS77")` returns 55 indicators with `module` field
- [ ] Verify AIDIS sample: `get_data("NSS77", {"module":"aidis","indicator_code":"2","state_code":"37","limit":"20"})`