### PR TITLE
feat: update ENERGY swagger and docs for year formats and filter params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NSS76 (NSS 76th Round - Disability + Housing & Drinking Water) with 25 indicators across two modules: survey_code=1 (Disability, indicators 1-13) covering disability prevalence, literacy, education, employment, care arrangements, and receipt of aid/help; survey_code=2 (Housing & drinking water, indicators 14-26) covering drinking water sources, sufficiency, treatment, housing characteristics, latrines, and flood experience. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-76/getNSS76FilterByIndicatorId` (swagger documents data endpoint only).
 
 ### Changed
+- ENERGY swagger updated from portal (v1.0.11): relaxed filter param patterns; year accepts YYYY-YY and YYYY; documented Supply/Consumption and indicator description strings for get_data.
 - Total datasets: 23 → 25 (NSS76, NSS75E)
 - list_datasets, get_indicators, and get_metadata updated to include NSS76 and NSS75E
 - Upgraded fastmcp from 3.0.0b1 to 3.3.1, moving from a beta to a stable release. The mcp SDK is now resolved transitively by fastmcp and is no longer pinned in requirements.txt.

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -489,7 +489,16 @@ class MoSPI:
                 timeout=30
             )
             response.raise_for_status()
-            return response.json()
+            result = response.json()
+            result["_note"] = (
+                "Two indicators: 1=Energy Balance (KToE), 2=Energy Balance (PetaJoules). "
+                "use_of_energy_balance_code: 1=Supply, 2=Consumption (get_data also accepts "
+                "'Supply'/'Consumption' strings). "
+                "get_data indicator_code accepts numeric codes or description strings. "
+                "year accepts YYYY-YY or YYYY formats (comma-separated). "
+                "Filter metadata API requires numeric indicator_code and use_of_energy_balance_code."
+            )
+            return result
         except requests.RequestException as e:
             return {"error": str(e), "statusCode": False}
 

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -469,6 +469,14 @@ def get_metadata(
             energy_code = use_of_energy_balance_code or 1
             result = mospi.get_energy_filters(indicator_code=ind_code, use_of_energy_balance_code=energy_code)
             result["api_params"] = get_swagger_param_definitions("ENERGY")
+            result["parameter_notes"] = (
+                "indicator_code: 1=KToE, 2=PetaJoules (get_data also accepts description strings). "
+                "use_of_energy_balance_code: 1=Supply, 2=Consumption for filter metadata; "
+                "get_data also accepts 'Supply'/'Consumption'. "
+                "year format: YYYY-YY or YYYY (comma-separated). "
+                "Optional filters: energy_commodities_code (1-10), energy_sub_commodities_code (1-12), "
+                "end_use_sector_code (1-10), end_use_sub_sector_code (1-22)."
+            )
             result["next_step"] = _next
             return _check_empty_metadata(result, dataset, indicator_code=indicator_code, use_of_energy_balance_code=use_of_energy_balance_code)
 
@@ -893,7 +901,7 @@ def list_datasets() -> dict:
             },
             "ENERGY": {
                 "name": "Energy Statistics",
-                "description": "2 indicators (KToE and PetaJoules) measuring energy balance across supply and consumption dimensions. Covers all energy commodities (coal, oil, gas, renewables, electricity) and tracks energy flows through production, transformation, and end-use sectors.",
+                "description": "2 indicators (KToE and PetaJoules) measuring energy balance across Supply and Consumption. Covers energy commodities (1-10), sub-commodities (1-12), end-use sectors (1-10), and sub-sectors (1-22). year accepts YYYY-YY or YYYY formats.",
                 "use_for": "Energy production, consumption patterns, fuel mix, sectoral energy use, climate analysis"
             },
             "AISHE": {

--- a/swagger/swagger_user_energy.yaml
+++ b/swagger/swagger_user_energy.yaml
@@ -17,66 +17,56 @@ paths:
       - name: indicator_code
         required: true
         in: query
+        description: Indicator code (1=KToE, 2=PetaJoules) or indicator description string
         schema:
-          default: Energy Balance ( in KToE )
+          default: "Energy Balance ( in KToE )"
           enum:
-          - Energy Balance ( in KToE )
-          - Energy Balance ( in PetaJoules )
+          - "Energy Balance ( in KToE )"
+          - "Energy Balance ( in PetaJoules )"
       - name: use_of_energy_balance_code
         required: true
         in: query
+        description: Supply or Consumption (filter API uses 1=Supply, 2=Consumption)
         schema:
-          default: Supply
+          default: "Supply"
           enum:
-          - Supply
-          - Consumption
+          - "Supply"
+          - "Consumption"
       - name: year
         in: query
-        description: Enter the Year (format YYYY-YY/YYYY. Comma separated for multiple
-          values)
+        description: Enter the Year (format YYYY-YY/YYYY. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d{4}-\d{2}(,\d{4}-\d{2})*$
       - name: energy_commodities_code
         in: query
-        description: Enter the Energy Commodities code (from 1 to 10. Comma separated
-          for multiple values)
+        description: Enter the Energy Commodities code (from 1 to 10. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: energy_sub_commodities_code
         in: query
-        description: Enter the Energy Sub_commodities code (from 1 to 12. Comma separated
-          for multiple values)
+        description: Enter the Energy Sub_commodities code (from 1 to 12. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: end_use_sector_code
         in: query
-        description: Enter the End Use Sector code (from 1 to 10. Comma separated
-          for multiple values)
+        description: Enter the End Use Sector code (from 1 to 10. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: end_use_sub_sector_code
         in: query
-        description: Enter the End Use Sub_sector code (from 1 to 22. Comma separated
-          for multiple values)
+        description: Enter the End Use Sub_sector code (from 1 to 22. Comma separated for multiple values)
         schema:
           type: string
-          pattern: ^\d+(,\d+)*$
       - name: limit
         in: query
         description: Number of records per page (default 10)
         schema:
           type: integer
-          pattern: ^\d+$
       - name: page
         in: query
         description: Enter the page no. (from 1 to n.)
         schema:
           type: string
-          pattern: ^\d+$
       - name: Format
         required: true
         in: query
@@ -88,9 +78,9 @@ paths:
           - JSON
           - CSV
       responses:
-        '200':
+        "200":
           description: A JSON array of user information
-        '400':
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -113,7 +103,7 @@ paths:
                   message:
                     type: string
                     example: Invalid request body
-        '409':
+        "409":
           description: Not Found
           content:
             application/json:
@@ -135,4 +125,4 @@ components:
       description: Bearer token to access these api endpoints
       name: Authorization
       in: header
-x-original-swagger-version: '2.0'
+x-original-swagger-version: "2.0"


### PR DESCRIPTION
## Summary
- Updates ENERGY (Energy Statistics) from portal swagger v1.0.11
- Relaxes strict regex patterns on filter params (comma-separated values)
- Documents **year** format: `YYYY-YY` and `YYYY` both supported
- Documents get_data accepts indicator description strings and Supply/Consumption labels

## Changes
- `swagger/swagger_user_energy.yaml` — official portal spec aligned
- `mospi/client.py` — updated ENERGY `_note` in get_indicators
- `mospi_server.py` — ENERGY `parameter_notes` + list_datasets description
- `CHANGELOG.md`

## Test plan
- [x] `pytest tests/test_mcp_server.py -k ENERGY` — 3/3 passed
- [ ] After merge: `./deploy.sh` on production
- [ ] Verify `get_data("ENERGY", {"indicator_code":"1","use_of_energy_balance_code":"1","limit":"1"})`