### PR TITLE
feat: merge NSS77 AIDIS module into NSS77 dataset (portal nss77a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NSS76 (NSS 76th Round - Disability + Housing & Drinking Water) with 25 indicators across two modules: survey_code=1 (Disability, indicators 1-13) covering disability prevalence, literacy, education, employment, care arrangements, and receipt of aid/help; survey_code=2 (Housing & drinking water, indicators 14-26) covering drinking water sources, sufficiency, treatment, housing characteristics, latrines, and flood experience. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-76/getNSS76FilterByIndicatorId` (swagger documents data endpoint only).
 
 ### Changed
+- NSS77 expanded to include AIDIS module (portal nss77a): 55 total indicators across `module=land_livestock` (33 indicators) and `module=aidis` (22 indicators, survey_code=1). Official AIDIS swagger (`swagger_user_nss77_aidis.yaml`) merged for filter validation. Module routing with auto-derivation for non-overlapping indicator codes.
 - Total datasets: 23 → 25 (NSS76, NSS75E)
 - list_datasets, get_indicators, and get_metadata updated to include NSS76 and NSS75E
 - Upgraded fastmcp from 3.0.0b1 to 3.3.1, moving from a beta to a stable release. The mcp SDK is now resolved transitively by fastmcp and is no longer pinned in requirements.txt.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
   Easter egg: hidden developer credits for the MoSPI eSankhyiki MCP Server.
 
   Made with love by:
@@ -72,7 +72,7 @@ This server provides AI-ready access to official Indian government statistics th
 | **NFHS** | National Family Health Survey | Fertility, infant mortality, maternal care, nutrition |
 | **ENVSTATS** | Environment Statistics | Climate, biodiversity, pollution, water resources, forests |
 | **RBI** | RBI Statistics | Foreign trade, forex reserves, exchange rates, balance of payments |
-| **NSS77** | NSS 77th Round (Land & Livestock) | Agricultural households, land ownership, farm income, crop insurance |
+| **NSS77** | NSS 77th Round (Land & Livestock + AIDIS) | Agricultural households, land & livestock, farm income; household assets, debt & borrowing (module=land_livestock or aidis) |
 | **NSS78** | NSS 78th Round (Living Conditions) | Drinking water, sanitation, digital connectivity, migration |
 | **CPIALRL** | CPI for Agricultural/Rural Labourers | Rural inflation, agricultural labourer cost of living |
 | **HCES** | Household Consumption Expenditure Survey | Consumer spending, poverty analysis, inequality (Gini) |
@@ -93,7 +93,7 @@ This server provides AI-ready access to official Indian government statistics th
 The server exposes 4 tools that follow a sequential workflow:
 
 ```
-list_datasets  →  get_indicators  →  get_metadata  →  get_data
+list_datasets  ΓåÆ  get_indicators  ΓåÆ  get_metadata  ΓåÆ  get_data
 ```
 
 | Step | Tool | Description |
@@ -259,17 +259,17 @@ Services:
 
 ```
 mospi-mcp-api/
-├── mospi_server.py          # FastMCP server - tools, validation, routing
-├── mospi/
-│   └── client.py            # MoSPI API client - HTTP requests to api.mospi.gov.in
-├── swagger/                 # Swagger YAML specs per dataset (source of truth for params)
-│   └── swagger_user_*.yaml
-├── observability/
-│   └── telemetry.py         # OpenTelemetry middleware for tracing
-├── tests/                   # Pytest suite (covering all 25 datasets)
-├── Dockerfile               # Production container with OTEL instrumentation
-├── docker-compose.yml       # Full stack with Jaeger
-└── requirements.txt
+Γö£ΓöÇΓöÇ mospi_server.py          # FastMCP server - tools, validation, routing
+Γö£ΓöÇΓöÇ mospi/
+Γöé   ΓööΓöÇΓöÇ client.py            # MoSPI API client - HTTP requests to api.mospi.gov.in
+Γö£ΓöÇΓöÇ swagger/                 # Swagger YAML specs per dataset (source of truth for params)
+Γöé   ΓööΓöÇΓöÇ swagger_user_*.yaml
+Γö£ΓöÇΓöÇ observability/
+Γöé   ΓööΓöÇΓöÇ telemetry.py         # OpenTelemetry middleware for tracing
+Γö£ΓöÇΓöÇ tests/                   # Pytest suite (covering all 25 datasets)
+Γö£ΓöÇΓöÇ Dockerfile               # Production container with OTEL instrumentation
+Γö£ΓöÇΓöÇ docker-compose.yml       # Full stack with Jaeger
+ΓööΓöÇΓöÇ requirements.txt
 ```
 
 ### Design Principles

--- a/definitions/nss77_aidis_definitions.json
+++ b/definitions/nss77_aidis_definitions.json
@@ -1,0 +1,112 @@
+[
+  {
+    "indicator_code": 2,
+    "name": "Average value of assets and cash loan per household by occupational category",
+    "description": "Average value of assets and amount of cash loan per household by occupational category of the households"
+  },
+  {
+    "indicator_code": 3,
+    "name": "Average value of assets and cash loan per household by household type",
+    "description": "Average value of assets and amount of cash loan per household by household type"
+  },
+  {
+    "indicator_code": 4,
+    "name": "Average value of assets and cash loan by household asset holding class",
+    "description": "Average value of assets and amount of cash loan per household by household asset holding class"
+  },
+  {
+    "indicator_code": 5,
+    "name": "Average value of assets and cash loan by quintile class of expenditure",
+    "description": "Average value of assets and amount of cash loan per household by quintile class of household expenditure"
+  },
+  {
+    "indicator_code": 6,
+    "name": "Average value of assets and cash loan by social group",
+    "description": "Average value of assets and amount of cash loan per household by social group"
+  },
+  {
+    "indicator_code": 8,
+    "name": "Households reporting fixed/financial assets and cash loan by occupational category",
+    "description": "Per 1000 number of households reporting fixed asset, financial asset and valuables and cash loan outstanding by occupational category"
+  },
+  {
+    "indicator_code": 9,
+    "name": "Average value of fixed and financial assets by occupational category",
+    "description": "Average value of fixed assets, financial assets by occupational category of the households"
+  },
+  {
+    "indicator_code": 10,
+    "name": "Households reporting assets and cash loan by occupational category",
+    "description": "Per 1000 number of households reporting assets of specified categories and cash loan outstanding as on 30.6.18 by occupational category"
+  },
+  {
+    "indicator_code": 11,
+    "name": "Average value of assets and cash loan by asset category",
+    "description": "Average value of assets by asset category and average value of cash loan outstanding by occupational category"
+  },
+  {
+    "indicator_code": 12,
+    "name": "Households with bullion and ornaments",
+    "description": "Per 1000 number of households reported having bullion and ornaments and average amount of bullion and ornaments per household"
+  },
+  {
+    "indicator_code": 16,
+    "name": "Fixed capital expenditure by occupational category and asset class (AIDIS)",
+    "description": "Number of households reporting fixed capital expenditure and expenditure on purchase of land and fixed capital formation by occupational category and household asset holding class"
+  },
+  {
+    "indicator_code": 17,
+    "name": "Fixed capital expenditure by household type (AIDIS)",
+    "description": "Number of households reporting fixed capital expenditure and expenditure on purchase of land and fixed capital formation by household type"
+  },
+  {
+    "indicator_code": 18,
+    "name": "Fixed capital expenditure by asset holding class (AIDIS)",
+    "description": "Number of households reporting fixed capital expenditure and expenditure on purchase of land and fixed capital formation by household asset holding class"
+  },
+  {
+    "indicator_code": 19,
+    "name": "Fixed capital expenditure on broad item categories (AIDIS)",
+    "description": "Per 1000 number of households reporting fixed capital expenditure on broad item categories and average value of expenditure by broad item categories"
+  },
+  {
+    "indicator_code": 24,
+    "name": "Household borrowing for capital expenditure (AIDIS)",
+    "description": "Proportion per 1000 of household reporting borrowing and average amount of borrowing per household for capital expenditure by major head of borrowing"
+  },
+  {
+    "indicator_code": 26,
+    "name": "Cash loans outstanding by occupational category (AIDIS)",
+    "description": "Number of households reporting cash loans outstanding and per Rs.1000 break-up of outstanding amount of cash loans by occupational category"
+  },
+  {
+    "indicator_code": 29,
+    "name": "Cash loans outstanding by credit agency (AIDIS)",
+    "description": "Number of households reporting cash loans outstanding as on 30.06.18 per thousand households and per Rs.1000 break-up by credit agency"
+  },
+  {
+    "indicator_code": 30,
+    "name": "Cash loans outstanding by credit agency and interest rate (AIDIS)",
+    "description": "Number of households reporting cash loans outstanding as on 30.06.18 by credit agency and rate of interest"
+  },
+  {
+    "indicator_code": 32,
+    "name": "Cash loans outstanding by asset class and credit agency (AIDIS)",
+    "description": "Number of households reporting cash loans outstanding as on 30.06.18 by household asset holding class and credit agency"
+  },
+  {
+    "indicator_code": 34,
+    "name": "Cash loans outstanding by purpose and credit agency (AIDIS)",
+    "description": "No. of hhs reporting cash loans outstanding as on 30.06.18 per thousand households and per Rs.1000 break-up by purpose of loan and credit agency"
+  },
+  {
+    "indicator_code": 36,
+    "name": "Cash loans outstanding by tenure of loan (AIDIS)",
+    "description": "Number of households reporting cash loans outstanding as on 30.06.2018 by tenure of loan"
+  },
+  {
+    "indicator_code": 38,
+    "name": "Cash loans outstanding by size class (AIDIS)",
+    "description": "Number of households per 1000 reporting cash loans outstanding as on 30.06.18 by size class of cash loan outstanding"
+  }
+]

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 MoSPI API Client
 Handles all API calls to the MoSPI data portal
 """
@@ -138,7 +138,7 @@ class MoSPI:
             return {
                 "indicators_by_frequency": result,
                 "_note": "frequency_code=1 (Annual) has 8 indicators including all wages. "
-                         "It already contains quarterly breakdowns — use quarter_code to filter. "
+                         "It already contains quarterly breakdowns ΓÇö use quarter_code to filter. "
                          "frequency_code=2 (Quarterly) has 4 indicators for quarterly bulletin tables. "
                          "frequency_code=3 (Monthly) has 3 indicators (2025+ data only). "
                          "Pick the frequency_code whose indicator set matches the query.",
@@ -355,10 +355,10 @@ class MoSPI:
                 "classification_years": ["2008", "2004", "1998", "1987"],
                 "_note": "classification_year is REQUIRED for ASI. It is the NIC classification version, NOT the data year. "
                          "Pick based on which data year you need: "
-                         "'1987' → 1992-93 to 1997-98 | "
-                         "'1998' → 1998-99 to 2003-04 | "
-                         "'2004' → 2004-05 to 2007-08 | "
-                         "'2008' → 2008-09 to 2023-24. "
+                         "'1987' ΓåÆ 1992-93 to 1997-98 | "
+                         "'1998' ΓåÆ 1998-99 to 2003-04 | "
+                         "'2004' ΓåÆ 2004-05 to 2007-08 | "
+                         "'2008' ΓåÆ 2008-09 to 2023-24. "
                          "Pass classification_year in get_metadata() and get_data().",
                 "statusCode": True,
             }
@@ -784,36 +784,180 @@ class MoSPI:
         except requests.RequestException as e:
             return {"error": str(e), "statusCode": False}
 
+    # NSS77 module routing ΓÇö Land & Livestock (nss77) + AIDIS (nss77a)
+    NSS77_LL_ONLY = frozenset({
+        21, 22, 23, 25, 27, 28, 31, 33, 35, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+    })
+    NSS77_AIDIS_ONLY = frozenset({2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 30, 38})
+    NSS77_OVERLAP = frozenset({16, 17, 18, 19, 24, 26, 29, 32, 34, 36})
+    NSS77_AIDIS_SURVEY_CODE = 1
+
+    @classmethod
+    def _normalize_nss77_module(cls, module: Optional[str]) -> Optional[str]:
+        if module is None:
+            return None
+        m = str(module).strip().lower()
+        if m in ("land_livestock", "land", "ll", "nss77"):
+            return "land_livestock"
+        if m in ("aidis", "nss77a", "a"):
+            return "aidis"
+        return None
+
+    @classmethod
+    def _nss77_module_for(cls, indicator_code: int, module: Optional[str] = None) -> Optional[str]:
+        normalized = cls._normalize_nss77_module(module)
+        if normalized:
+            return normalized
+        if indicator_code in cls.NSS77_AIDIS_ONLY:
+            return "aidis"
+        if indicator_code in cls.NSS77_LL_ONLY:
+            return "land_livestock"
+        if indicator_code in cls.NSS77_OVERLAP:
+            return None
+        return None
+
     def get_nss77_indicators(self) -> Dict[str, Any]:
         """Fetch list of NSS77 indicators from MoSPI API.
 
-        Returns indicators from NSS 77th Round (Situation Assessment Survey of Agricultural Households).
+        Returns 55 indicators from NSS 77th Round ΓÇö two modules combined:
+        - module=land_livestock (portal product nss77): 33 indicators on agricultural
+          households, land ownership, livestock, farm income, and crop insurance.
+        - module=aidis (portal product nss77a): 22 indicators on household assets,
+          debt, borrowing, and cash loans outstanding (AIDIS, survey_code=1).
         """
         try:
-            response = self.session.get(
+            ll_resp = self.session.get(
                 f"{self.base_url}/api/nss-77/getIndicatorList",
-                timeout=30
+                timeout=30,
             )
-            response.raise_for_status()
-            return response.json()
+            ll_resp.raise_for_status()
+            result = ll_resp.json()
+
+            aidis_resp = self.session.get(
+                f"{self.base_url}/api/nss-77/getNss77AidisIndicatorList",
+                params={"survey_code": self.NSS77_AIDIS_SURVEY_CODE},
+                timeout=30,
+            )
+            aidis_resp.raise_for_status()
+
+            ll_data = [
+                {**item, "module": "land_livestock"}
+                for item in result.get("data", [])
+            ]
+            aidis_data = [
+                {
+                    **item,
+                    "module": "aidis",
+                    "survey_code": self.NSS77_AIDIS_SURVEY_CODE,
+                }
+                for item in aidis_resp.json().get("data", [])
+            ]
+
+            result["data"] = ll_data + aidis_data
+            result["count"] = len(result["data"])
+            result["_note"] = (
+                "Two modules share indicator_code values ΓÇö always pass module in "
+                "get_metadata/get_data when codes overlap (16-19, 24, 26, 29, 32, 34, 36). "
+                "module=land_livestock: Land & Livestock (codes 16-51, 23 unique). "
+                "module=aidis: All India Debt & Investment Survey (22 indicators, survey_code=1). "
+                "Module is auto-derived for codes unique to one module."
+            )
+            return result
         except requests.RequestException as e:
             return {"error": str(e), "statusCode": False}
 
-    def get_nss77_filters(self, indicator_code: int) -> Dict[str, Any]:
+    def get_nss77_filters(
+        self,
+        indicator_code: int,
+        module: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Fetch available NSS77 filters for given indicator.
 
         Args:
-            indicator_code: Indicator code (16-51)
+            indicator_code: Indicator code (varies by module; see get_nss77_indicators).
+            module: land_livestock or aidis. Required when indicator_code is ambiguous.
         """
-        params = {"indicator_code": indicator_code}
+        resolved = self._nss77_module_for(indicator_code, module)
+        if resolved is None:
+            return {
+                "error": (
+                    f"indicator_code {indicator_code} exists in both NSS77 modules. "
+                    "Pass module='land_livestock' or module='aidis'."
+                ),
+                "statusCode": False,
+                "ambiguous_codes": sorted(self.NSS77_OVERLAP),
+            }
 
         try:
-            response = self.session.get(
-                f"{self.base_url}/api/nss-77/getFilterByIndicatorId",
-                params=params,
-                timeout=30
-            )
+            if resolved == "aidis":
+                response = self.session.get(
+                    f"{self.base_url}/api/nss-77/getNss77AidisFiltersByIndicatorCode",
+                    params={
+                        "indicator_code": indicator_code,
+                        "survey_code": self.NSS77_AIDIS_SURVEY_CODE,
+                    },
+                    timeout=30,
+                )
+            else:
+                response = self.session.get(
+                    f"{self.base_url}/api/nss-77/getFilterByIndicatorId",
+                    params={"indicator_code": indicator_code},
+                    timeout=30,
+                )
             response.raise_for_status()
+            payload = response.json()
+            payload["module"] = resolved
+            if resolved == "aidis":
+                payload["survey_code"] = self.NSS77_AIDIS_SURVEY_CODE
+            return payload
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    def get_nss77_data(self, params: Optional[Dict] = None) -> Dict[str, Any]:
+        """Fetch NSS77 records, routing to Land & Livestock or AIDIS endpoint."""
+        if not params:
+            return {"error": "indicator_code is required for NSS77", "statusCode": False}
+
+        params = {k: v for k, v in params.items() if v is not None}
+        module_arg = params.pop("module", None)
+
+        try:
+            indicator_code = int(str(params["indicator_code"]).split(",")[0])
+        except (KeyError, ValueError, AttributeError):
+            return {"error": "indicator_code is required for NSS77", "statusCode": False}
+
+        resolved = self._nss77_module_for(indicator_code, module_arg)
+        if resolved is None:
+            return {
+                "error": (
+                    f"indicator_code {indicator_code} exists in both NSS77 modules. "
+                    "Pass module='land_livestock' or module='aidis' in filters."
+                ),
+                "statusCode": False,
+                "ambiguous_codes": sorted(self.NSS77_OVERLAP),
+            }
+
+        if resolved == "aidis":
+            params["survey_code"] = str(self.NSS77_AIDIS_SURVEY_CODE)
+            try:
+                limit = int(params.get("limit", 20))
+            except (ValueError, TypeError):
+                limit = 20
+            if limit < 20:
+                limit = 20
+            elif limit > 100:
+                limit = 100
+            params["limit"] = str(limit)
+            endpoint = f"{self.base_url}/api/nss-77/getNss77AidisRecords"
+        else:
+            endpoint = f"{self.base_url}/api/nss-77/getNss77Records"
+
+        format_param = params.get("Format", "JSON")
+        try:
+            response = self.session.get(endpoint, params=params, timeout=30)
+            response.raise_for_status()
+            if format_param == "CSV":
+                return {"data": response.text, "format": "CSV"}
             return response.json()
         except requests.RequestException as e:
             return {"error": str(e), "statusCode": False}
@@ -860,7 +1004,7 @@ class MoSPI:
     def get_nss79_indicators(self) -> Dict[str, Any]:
         """Fetch list of NSS79 indicators from MoSPI API.
 
-        Returns all 35 indicators from NSS 79th Round — two survey modules combined:
+        Returns all 35 indicators from NSS 79th Round ΓÇö two survey modules combined:
         - survey_code=1 (CAMS): 28 indicators on education, health expenditure,
           financial inclusion, digital literacy, and household living conditions.
         - survey_code=2 (AYUSH): 7 indicators on AYUSH awareness, usage,
@@ -928,7 +1072,7 @@ class MoSPI:
     def get_nss76_indicators(self) -> Dict[str, Any]:
         """Fetch list of NSS76 indicators from MoSPI API.
 
-        Returns 25 indicators from NSS 76th Round — two survey modules combined:
+        Returns 25 indicators from NSS 76th Round ΓÇö two survey modules combined:
         - survey_code=1 (Disability): 13 indicators on disability prevalence,
           literacy, education, employment, and aid for persons with disability.
         - survey_code=2 (Housing & water): 12 indicators on drinking water,
@@ -1085,7 +1229,7 @@ class MoSPI:
     def get_nss80_indicators(self) -> Dict[str, Any]:
         """Fetch list of NSS80 indicators from MoSPI API.
 
-        Returns all 38 indicators from NSS 80th Round — two survey modules combined:
+        Returns all 38 indicators from NSS 80th Round ΓÇö two survey modules combined:
         - survey_code=1 (Telecom (CMST)): 20 indicators on telecommunications, internet usage,
           mobile phone ownership, cybercrime reporting, household connectivity,
           online purchases, and digital connectivity.

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -1,4 +1,4 @@
-import sys
+﻿import sys
 import os
 import json
 import yaml
@@ -40,6 +40,24 @@ def enrich_indicators(result: Dict[str, Any], dataset: str) -> Dict[str, Any]:
     - result["data"]["indicator"] = list  (NAS, ENERGY, CPIALRL)
     - result["indicator"] = list  (NSS78)
     """
+    if dataset == "NSS77":
+        ll_definitions = load_definitions(dataset)
+        aidis_filepath = os.path.join(DEFINITIONS_DIR, "nss77_aidis_definitions.json")
+        aidis_definitions: Dict[int, Dict[str, str]] = {}
+        if os.path.exists(aidis_filepath):
+            with open(aidis_filepath, "r") as f:
+                aidis_definitions = {d["indicator_code"]: d for d in json.load(f)}
+
+        for indicator in result.get("data", []):
+            code = indicator.get("indicator_code") or indicator.get("code")
+            module = indicator.get("module", "land_livestock")
+            definitions = aidis_definitions if module == "aidis" else ll_definitions
+            if code in definitions:
+                indicator["definition"] = definitions[code].get("description", "")
+            elif indicator.get("description"):
+                indicator["definition"] = indicator["description"]
+        return result
+
     definitions = load_definitions(dataset)
     if not definitions:
         return result
@@ -66,7 +84,7 @@ def log(msg: str):
 # Initialize FastMCP server
 mcp = FastMCP("MoSPI Data Server", version="2.3.0")
 
-# Disable listChanged notifications — ChatGPT opens a persistent GET SSE stream
+# Disable listChanged notifications ΓÇö ChatGPT opens a persistent GET SSE stream
 # when listChanged:true, waiting for notifications that never come in stateless mode,
 # causing 424 errors. Setting to false tells ChatGPT not to subscribe.
 mcp._mcp_server.notification_options.tools_changed = False
@@ -122,6 +140,40 @@ DATASETS_REQUIRING_INDICATOR = [
 ]
 
 
+def _resolve_swagger_parameters(spec: dict, endpoint_path: str) -> list:
+    """Load GET parameters for an endpoint, resolving component $ref entries."""
+    raw_params = (
+        spec.get("paths", {})
+        .get(endpoint_path, {})
+        .get("get", {})
+        .get("parameters", [])
+    )
+    components = spec.get("components", {}).get("parameters", {})
+    resolved = []
+    for param in raw_params:
+        if isinstance(param, dict) and "$ref" in param:
+            ref_key = param["$ref"].split("/")[-1]
+            component = components.get(ref_key)
+            if component:
+                resolved.append(component)
+        else:
+            resolved.append(param)
+    return resolved
+
+
+def _merge_param_definitions(*param_lists: list) -> list:
+    """Merge swagger parameter lists, keeping the first definition for each name."""
+    merged = []
+    seen = set()
+    for params in param_lists:
+        for param in params:
+            name = param.get("name")
+            if name and name not in seen:
+                merged.append(param)
+                seen.add(name)
+    return merged
+
+
 def get_swagger_param_definitions(dataset: str) -> list:
     """Load full param definitions from swagger spec for a dataset."""
     dataset_upper = dataset.upper()
@@ -131,9 +183,21 @@ def get_swagger_param_definitions(dataset: str) -> list:
     swagger_path = os.path.join(SWAGGER_DIR, yaml_file)
     if not os.path.exists(swagger_path):
         return []
-    with open(swagger_path, 'r') as f:
+    with open(swagger_path, "r") as f:
         spec = yaml.safe_load(f)
-    return spec.get("paths", {}).get(endpoint_path, {}).get("get", {}).get("parameters", [])
+    params = _resolve_swagger_parameters(spec, endpoint_path)
+
+    if dataset_upper == "NSS77":
+        aidis_path = os.path.join(SWAGGER_DIR, "swagger_user_nss77_aidis.yaml")
+        if os.path.exists(aidis_path):
+            with open(aidis_path, "r") as f:
+                aidis_spec = yaml.safe_load(f)
+            aidis_params = _resolve_swagger_parameters(
+                aidis_spec, "/api/nss-77/getNss77AidisRecords"
+            )
+            params = _merge_param_definitions(params, aidis_params)
+
+    return params
 
 
 def get_swagger_params(dataset: str) -> list:
@@ -162,7 +226,7 @@ def validate_filters(dataset: str, filters: Dict[str, Any]) -> Dict[str, Any]:
             "hint": f"Invalid params: {invalid}. Valid params: {valid_params}."
         }
 
-    # Check for missing required params (exclude Format — auto-handled by client)
+    # Check for missing required params (exclude Format ΓÇö auto-handled by client)
     missing = [
         p["name"] for p in param_defs
         if p.get("required") and p["name"] != "Format" and p["name"] not in filters
@@ -241,7 +305,7 @@ def get_indicators(
     """
     Returns the full list of available indicators for a given dataset.
 
-    Datasets often have broader coverage than expected — for example, ASI covers
+    Datasets often have broader coverage than expected ΓÇö for example, ASI covers
     57 indicators (capital structure, wages, employment, GVA, fuel consumption),
     and GENDER covers 147 indicators across health, education, labor, and crime.
 
@@ -251,10 +315,10 @@ def get_indicators(
       - PLFS frequency_code=3 (Monthly): indicators 1-3 only
       frequency_code selects the indicator set, not time granularity.
 
-    Step 2 of: list_datasets → get_indicators → get_metadata → get_data
+    Step 2 of: list_datasets ΓåÆ get_indicators ΓåÆ get_metadata ΓåÆ get_data
 
     Args:
-        dataset: Dataset name — one of: PLFS, CPI, IIP, ASI, NAS, WPI,
+        dataset: Dataset name ΓÇö one of: PLFS, CPI, IIP, ASI, NAS, WPI,
                  ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI,
                  NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
                  For CPI, IIP, WPI: returns available base years and frequencies.
@@ -328,6 +392,7 @@ def get_metadata(
     use_of_energy_balance_code: Optional[int] = None,
     sub_indicator_code: Optional[int] = None,
     survey_code: Optional[int] = None,
+    module: Optional[str] = None,
     Format: Optional[str] = None,
     type: Optional[str] = None
 ) -> dict:
@@ -335,14 +400,14 @@ def get_metadata(
     Returns the valid filter values (states, years, quarters, etc.) for a
     given dataset and indicator.
 
-    Filter codes are arbitrary and dataset-specific — for example, PLFS
+    Filter codes are arbitrary and dataset-specific ΓÇö for example, PLFS
     state_code 99 means "All India", and NAS frequency_code 1 means "Annual".
     These values cannot be inferred or guessed from parameter names alone.
 
     The returned filter_values and api_params should be used as-is when
     calling get_data.
 
-    Step 3 of: list_datasets → get_indicators → get_metadata → get_data
+    Step 3 of: list_datasets ΓåÆ get_indicators ΓåÆ get_metadata ΓåÆ get_data
 
     Args:
         dataset: Dataset name (same values as get_indicators).
@@ -364,7 +429,11 @@ def get_metadata(
         series: For CPI and NAS only ("Current"/"Back").
         use_of_energy_balance_code: For ENERGY only (1=Supply, 2=Consumption).
         survey_code: For NSS76 (1=Disability, 2=Housing & drinking water), NSS75E
-                     (2=Education, indicators 43-55), and NSS80 (1=Telecom (CMST), 2=Education (CMSE)).
+                     (2=Education, indicators 43-55), NSS80 (1=Telecom (CMST), 2=Education (CMSE)),
+                     and NSS77 AIDIS module (always 1).
+        module: For NSS77 only ΓÇö land_livestock (portal nss77) or aidis (portal nss77a).
+                Required when indicator_code overlaps both modules (16-19, 24, 26, 29, 32, 34, 36).
+                Auto-derived for codes unique to one module.
 
     Returns:
         dict with 'filter_values' (valid codes for each parameter),
@@ -373,7 +442,7 @@ def get_metadata(
     """
     dataset = dataset.upper()
 
-    # Validate numeric params — FastMCP doesn't enforce type hints
+    # Validate numeric params ΓÇö FastMCP doesn't enforce type hints
     indicator_code, err = _safe_int(indicator_code, "indicator_code")
     if err: return err
     frequency_code, err = _safe_int(frequency_code, "frequency_code")
@@ -532,10 +601,20 @@ def get_metadata(
         elif dataset == "NSS77":
             if indicator_code is None:
                 return {"error": "indicator_code is required for NSS77"}
-            result = mospi.get_nss77_filters(indicator_code=indicator_code)
+            result = mospi.get_nss77_filters(indicator_code=indicator_code, module=module)
+            if "error" in result and result.get("statusCode") is False:
+                return result
             result["api_params"] = get_swagger_param_definitions("NSS77")
+            result["parameter_notes"] = (
+                "NSS77 has two modules: module=land_livestock (33 indicators, Land & Livestock) "
+                "and module=aidis (22 indicators, AIDIS / nss77a, survey_code=1). "
+                "Pass module when indicator_code is ambiguous (16-19, 24, 26, 29, 32, 34, 36). "
+                "AIDIS filter/data params follow swagger_user_nss77_aidis.yaml "
+                "(e.g. tenure_agency_code, size_class_code, nature_of_interest_code, survey_year_code). "
+                "AIDIS data API: limit 20ΓÇô100 (default 20). state_code=37 is All-India."
+            )
             result["next_step"] = _next
-            return _check_empty_metadata(result, dataset, indicator_code=indicator_code)
+            return _check_empty_metadata(result, dataset, indicator_code=indicator_code, module=module)
 
         elif dataset == "NSS78":
             if indicator_code is None:
@@ -680,13 +759,13 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     Fetches statistical data from a MoSPI dataset.
 
     This is the final step of the workflow. It requires filter values from
-    get_metadata — filter codes are arbitrary (e.g., indicator_code=3 means
+    get_metadata ΓÇö filter codes are arbitrary (e.g., indicator_code=3 means
     "Unemployment Rate" in PLFS but something different in other datasets).
 
     All filter parameters including limit and page go inside the filters dict,
     not as top-level arguments.
 
-    Step 4 of: list_datasets → get_indicators → get_metadata → get_data
+    Step 4 of: list_datasets ΓåÆ get_indicators ΓåÆ get_metadata ΓåÆ get_data
 
     Args:
         dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY,
@@ -805,7 +884,10 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     if not validation["valid"]:
         return {"error": "Invalid parameters", **validation}
 
-    result = mospi.get_data(api_dataset, transformed_filters)
+    if dataset == "NSS77":
+        result = mospi.get_nss77_data(transformed_filters)
+    else:
+        result = mospi.get_data(api_dataset, transformed_filters)
 
     # Upstream error (500s, timeouts, etc.)
     if isinstance(result, dict) and "error" in result and "msg" not in result:
@@ -824,11 +906,11 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
         result["troubleshooting"] = (
             f"No data found for dataset '{dataset}' with the given filters. "
             "Most common causes: "
-            "1) Out-of-range codes — verify indicator_code and other numeric codes "
+            "1) Out-of-range codes ΓÇö verify indicator_code and other numeric codes "
             "match values from get_metadata(). "
-            "2) Incompatible filter combination — some filters are mutually exclusive. "
+            "2) Incompatible filter combination ΓÇö some filters are mutually exclusive. "
             "3) Comma-separated values where only single values are accepted. "
-            "4) Optional filters narrowing results too much — try removing optional params."
+            "4) Optional filters narrowing results too much ΓÇö try removing optional params."
         )
         result["suggestion"] = f"Call get_metadata(dataset='{dataset}') to verify valid filter values."
 
@@ -841,18 +923,18 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
 def list_datasets() -> dict:
     """
     Returns an overview of all MoSPI statistical datasets with descriptions and coverage.
-    This is the starting point — call this first to identify the right dataset.
+    This is the starting point ΓÇö call this first to identify the right dataset.
 
     The API covers 500+ indicators across employment, prices, industry, national
     accounts, health, education, disability, housing, environment, trade, and more. Each dataset has
-    its own indicator codes, filter parameters, and valid values — these are not
+    its own indicator codes, filter parameters, and valid values ΓÇö these are not
     standardized and cannot be inferred or guessed from parameter names alone.
 
     Four-step workflow (each step depends on the previous):
-      1. list_datasets() — identify the dataset
-      2. get_indicators(dataset) — list available indicators
-      3. get_metadata(dataset, indicator_code) — retrieve valid filter values
-      4. get_data(dataset, filters) — fetch the data
+      1. list_datasets() ΓÇö identify the dataset
+      2. get_indicators(dataset) ΓÇö list available indicators
+      3. get_metadata(dataset, indicator_code) ΓÇö retrieve valid filter values
+      4. get_data(dataset, filters) ΓÇö fetch the data
 
     Returns:
         dict with 'datasets' (name, description, use_for for each dataset)
@@ -863,7 +945,7 @@ def list_datasets() -> dict:
         "datasets": {
             "PLFS": {
                 "name": "Periodic Labour Force Survey",
-                "description": "8 indicators covering labor market dynamics: Labour Force Participation Rate (LFPR), Worker Population Ratio (WPR), Unemployment Rate (UR), worker distribution by sector/industry, employment conditions for regular wage employees, and earnings data across three employment types—regular wages, casual labor, and self-employment.",
+                "description": "8 indicators covering labor market dynamics: Labour Force Participation Rate (LFPR), Worker Population Ratio (WPR), Unemployment Rate (UR), worker distribution by sector/industry, employment conditions for regular wage employees, and earnings data across three employment typesΓÇöregular wages, casual labor, and self-employment.",
                 "use_for": "Jobs, unemployment, wages, workforce participation, employment conditions"
             },
             "CPI": {
@@ -888,7 +970,7 @@ def list_datasets() -> dict:
             },
             "WPI": {
                 "name": "Wholesale Price Index",
-                "description": "Hierarchical commodity structure with 1000+ items across 5 levels: Major Groups (Primary articles, Fuel & power, Manufactured products, Food index) → Groups (22) → Sub-groups (90+) → Sub-sub-groups → Items. Tracks wholesale/producer price inflation monthly. Three base years available: 2011-12 (latest, default), 2004-05, and 1993-94.",
+                "description": "Hierarchical commodity structure with 1000+ items across 5 levels: Major Groups (Primary articles, Fuel & power, Manufactured products, Food index) ΓåÆ Groups (22) ΓåÆ Sub-groups (90+) ΓåÆ Sub-sub-groups ΓåÆ Items. Tracks wholesale/producer price inflation monthly. Three base years available: 2011-12 (latest, default), 2004-05, and 1993-94.",
                 "use_for": "Wholesale inflation, producer prices, commodity price trends"
             },
             "ENERGY": {
@@ -918,18 +1000,18 @@ def list_datasets() -> dict:
             },
             "ENVSTATS": {
                 "name": "Environment Statistics",
-                "description": "124 indicators covering: climate (temperature, rainfall, heat/cold waves, cyclones), water resources (wetlands, watersheds, rivers, groundwater, reservoirs, water quality), land (soil types, degradation, land use/cover), forests (area, cover, fire, carbon stock, tree cover), biodiversity (faunal diversity including global species counts by phylum—mammals, birds, reptiles, fish, etc., plant status), minerals, energy (coal/lignite reserves, power generation), agriculture (crops, fertilizers, pesticides, organic farming, livestock), pollution (air quality, noise, industrial clusters), waste (municipal, hazardous, biomedical, sewage), natural disasters (earthquakes, extreme events, deaths, government expenditure), water/sanitation access, transport, disease outbreaks, and environmental expenditure (government + corporate CSR).",
+                "description": "124 indicators covering: climate (temperature, rainfall, heat/cold waves, cyclones), water resources (wetlands, watersheds, rivers, groundwater, reservoirs, water quality), land (soil types, degradation, land use/cover), forests (area, cover, fire, carbon stock, tree cover), biodiversity (faunal diversity including global species counts by phylumΓÇömammals, birds, reptiles, fish, etc., plant status), minerals, energy (coal/lignite reserves, power generation), agriculture (crops, fertilizers, pesticides, organic farming, livestock), pollution (air quality, noise, industrial clusters), waste (municipal, hazardous, biomedical, sewage), natural disasters (earthquakes, extreme events, deaths, government expenditure), water/sanitation access, transport, disease outbreaks, and environmental expenditure (government + corporate CSR).",
                 "use_for": "Climate, biodiversity, species counts, water resources, forests, land use, pollution, waste, natural disasters, environmental health"
             },
             "RBI": {
                 "name": "RBI Statistics",
-                "description": "39 indicators on external sector: foreign trade (direction by country, commodity exports/imports in USD/INR), balance of payments (overall BoP, invisibles, key components—quarterly and annual), external debt, forex reserves, NRI deposits, and exchange rates (155 currencies, SDR, monthly averages, highs/lows, forward premia). Comprehensive for trade and currency analysis.",
+                "description": "39 indicators on external sector: foreign trade (direction by country, commodity exports/imports in USD/INR), balance of payments (overall BoP, invisibles, key componentsΓÇöquarterly and annual), external debt, forex reserves, NRI deposits, and exchange rates (155 currencies, SDR, monthly averages, highs/lows, forward premia). Comprehensive for trade and currency analysis.",
                 "use_for": "Foreign trade, exports, imports, balance of payments, forex reserves, exchange rates, external debt, NRI deposits"
             },
             "NSS77": {
-                "name": "NSS77 (77th Round - Land & Livestock)",
-                "description": "33 indicators on agricultural households: land ownership and possession (by size class, leasing patterns), livestock holdings, farm economics (income, expenses, crop production, GVA), crop marketing (disposal agencies, MSP awareness, satisfaction levels), input usage (seeds, farming resources), agricultural loans and insurance (coverage, crop loss, claim status). Comprehensive rural livelihoods data.",
-                "use_for": "Agricultural households, land ownership, livestock, farm income, crop production, agricultural loans, crop insurance, MSP awareness"
+                "name": "NSS77 (77th Round - Land & Livestock + AIDIS)",
+                "description": "55 indicators from two modules of NSS 77th Round. Land & Livestock module (module=land_livestock, portal nss77, 33 indicators, codes 16-51): agricultural households, land ownership and possession, livestock holdings, farm income and expenses, crop marketing, MSP awareness, and crop insurance. AIDIS module (module=aidis, portal nss77a, 22 indicators, survey_code=1): household assets, fixed capital expenditure, borrowing, cash loans outstanding by credit agency, purpose, tenure, and size class. Pass module when indicator_code overlaps (16-19, 24, 26, 29, 32, 34, 36).",
+                "use_for": "Agricultural households, land ownership, livestock, farm income, crop insurance, household debt, assets, borrowing, cash loans, AIDIS, investment survey"
             },
             "NSS78": {
                 "name": "NSS78 (78th Round - Living Conditions)",
@@ -943,7 +1025,7 @@ def list_datasets() -> dict:
             },
             "CPIALRL": {
                 "name": "CPI for Agricultural/Rural Labourers",
-                "description": "2 indicators: General Index and Group Index for two worker categories—Agricultural Labourers (AL) and Rural Labourers (RL). Separate inflation series measuring cost of living for India's most vulnerable rural workforce segments.",
+                "description": "2 indicators: General Index and Group Index for two worker categoriesΓÇöAgricultural Labourers (AL) and Rural Labourers (RL). Separate inflation series measuring cost of living for India's most vulnerable rural workforce segments.",
                 "use_for": "Rural inflation, agricultural labourer cost of living, rural wage indexing"
             },
             "HCES": {
@@ -988,10 +1070,10 @@ def list_datasets() -> dict:
 },
         },
         "workflow": [
-            "1. list_datasets() — identify the relevant dataset",
-            "2. get_indicators(dataset) — list available indicators",
-            "3. get_metadata(dataset, indicator_code) — retrieve valid filter values",
-            "4. get_data(dataset, filters) — fetch the data using filter values from step 3"
+            "1. list_datasets() ΓÇö identify the relevant dataset",
+            "2. get_indicators(dataset) ΓÇö list available indicators",
+            "3. get_metadata(dataset, indicator_code) ΓÇö retrieve valid filter values",
+            "4. get_data(dataset, filters) ΓÇö fetch the data using filter values from step 3"
         ],
         "next_step": "get_indicators(dataset) to list available indicators for the chosen dataset."
     }

--- a/swagger/swagger_user_nss77.yaml
+++ b/swagger/swagger_user_nss77.yaml
@@ -1,21 +1,42 @@
-openapi: 3.0.1
+﻿openapi: 3.0.1
 info:
-  title: National Sample Survey (NSS)
-  version: 1.0.11
+  title: National Sample Survey (NSS 77th Round)
+  version: 1.0.12
+  description: |
+    NSS 77th Round ΓÇö two modules on the same API base `/api/nss-77/`:
+    - **land_livestock** (portal `nss77`): `getIndicatorList`, `getFilterByIndicatorId`, `getNss77Records`
+    - **aidis** (portal `nss77a`): see `swagger_user_nss77_aidis.yaml` ΓÇö `getNss77AidisRecords` (survey_code=1, limit 20ΓÇô100)
 servers:
 - url: https://api.mospi.gov.in/
 tags:
-- name: National Sample Survey (NSS 77 ROUND).
-  description: Indicator-wise National Sample Survey (NSS 77 ROUND).
+- name: NSS77
+  description: NSS 77th Round ΓÇö Land & Livestock + AIDIS (Debt & Investment).
 paths:
   /api/nss-77/getNss77Records:
     get:
       tags:
-      - National Sample Survey (NSS 77 ROUND).
-      description:
-      - Indicator-wise National Sample Survey (NSS 77 ROUND).
+      - NSS77
+      description: |
+        Data endpoint for NSS77. Routes by `module`:
+        - `land_livestock` ΓåÆ `/api/nss-77/getNss77Records`
+        - `aidis` ΓåÆ `/api/nss-77/getNss77AidisRecords` (requires `survey_code=1`, minimum `limit=20`)
+        Pass `module` when `indicator_code` is ambiguous (16-19, 24, 26, 29, 32, 34, 36).
       operationId: NSS77IndicatorValues.
       parameters:
+      - name: module
+        in: query
+        description: Survey module ΓÇö land_livestock (Land & Livestock) or aidis (AIDIS / nss77a). Required for overlapping indicator codes.
+        schema:
+          type: string
+          enum:
+          - land_livestock
+          - aidis
+      - name: survey_code
+        in: query
+        description: Required for AIDIS module (always 1). Auto-set when module=aidis.
+        schema:
+          type: string
+          pattern: ^\d+(,\d+)*$
       - name: indicator_code
         required: true
         in: query
@@ -399,7 +420,7 @@ paths:
           pattern: ^\d+(,\d+)*$
       - name: sub_indicator_code
         in: query
-        description: Enter the Sub Indicator code
+        description: Enter the Sub Indicator code (Land & Livestock module)
         schema:
           type: string
           pattern: ^\d+(,\d+)*$

--- a/swagger/swagger_user_nss77_aidis.yaml
+++ b/swagger/swagger_user_nss77_aidis.yaml
@@ -1,0 +1,560 @@
+openapi: 3.0.1
+
+info:
+  title: API for NSS-77 AIDIS (All India Debt and Investment Survey)
+  description: >
+    NSS-77 AIDIS module APIs — survey list, indicators, filters, paginated
+    records, and Excel download. All endpoints return a JSON envelope with a
+    boolean `statusCode` flag and a human-readable `msg`.
+  version: 1.0.0
+
+servers:
+  - url: https://api.mospi.gov.in
+    description: Production server
+
+tags:
+  - name: All India Debt & Investment Survey (NSS 77 Round)
+    description: All India Debt and Investment Survey (AIDIS) APIs
+
+paths:
+  /api/nss-77/getNss77AidisSurveyList:
+    get:
+      tags:
+        - NSS-77 AIDIS
+      summary: Get survey list
+      description: Returns the list of available AIDIS surveys (survey_code + description).
+      responses:
+        "200":
+          description: Survey list fetched successfully (data may be an empty array).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Survey"
+                  count:
+                    type: integer
+                    example: 2
+                  msg:
+                    type: string
+                    example: Survey list fetched successfully
+                  statusCode:
+                    type: boolean
+                    example: true
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/nss-77/getNss77AidisIndicatorList:
+    get:
+      tags:
+        - NSS-77 AIDIS
+      summary: Get indicator list (survey-wise)
+      description: >
+        Returns indicators available for a given survey. Optionally filtered by
+        visualization status (`viz_status`).
+      parameters:
+        - $ref: "#/components/parameters/SurveyCodeRequired"
+        - in: query
+          name: viz_status
+          required: false
+          description: Optional visualization-status filter (must exist in indicator table).
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Indicator list fetched (data may be empty with msg "No Data Found").
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Indicator"
+                  count:
+                    type: integer
+                    example: 12
+                  msg:
+                    type: string
+                    example: Data fetched successfully
+                  statusCode:
+                    type: boolean
+                    example: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/nss-77/getNss77AidisFiltersByIndicatorCode:
+    get:
+      tags:
+        - NSS-77 AIDIS
+      summary: Get filters by indicator code
+      description: >
+        Returns the available dimension filter lists (state, sector, gender,
+        social_group, etc.) plus the sub-indicator list for the given
+        indicator + survey. Only dimensions that have data are present in the
+        `data` object.
+      parameters:
+        - $ref: "#/components/parameters/IndicatorCodeRequired"
+        - $ref: "#/components/parameters/SurveyCodeRequired"
+        - $ref: "#/components/parameters/SubIndicatorCode"
+      responses:
+        "200":
+          description: Filters fetched successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    description: >
+                      Map of dimension name -> list of { code, description }.
+                      Keys are present only when that dimension has data.
+                      Always includes the `sub_indicator` array.
+                    properties:
+                      sub_indicator:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/SubIndicator"
+                    additionalProperties:
+                      type: array
+                      items:
+                        $ref: "#/components/schemas/FilterOption"
+                  msg:
+                    type: string
+                    example: Filters fetched successfully
+                  statusCode:
+                    type: boolean
+                    example: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/nss-77/getNss77AidisRecords:
+    get:
+      tags:
+        - NSS-77 AIDIS
+      summary: Get paginated AIDIS records
+      description: >
+        Returns paginated AIDIS data rows for the given indicator + survey,
+        optionally narrowed by sub-indicator and any of the dimension filters.
+        Dimension filters accept comma-separated integer codes.
+      parameters:
+        - $ref: "#/components/parameters/IndicatorCodeRequired"
+        - $ref: "#/components/parameters/SurveyCodeRequired"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/SubIndicatorCode"
+        - $ref: "#/components/parameters/StateCode"
+        - $ref: "#/components/parameters/SectorCode"
+        - $ref: "#/components/parameters/GenderCode"
+        - $ref: "#/components/parameters/SocialGroupCode"
+        - $ref: "#/components/parameters/OccupationalCategoryCode"
+        - $ref: "#/components/parameters/HouseholdTypeCode"
+        - $ref: "#/components/parameters/QuintileClassCode"
+        - $ref: "#/components/parameters/AssetHoldingClassCode"
+        - $ref: "#/components/parameters/CreditAgencyCode"
+        - $ref: "#/components/parameters/NatureOfInterestCode"
+        - $ref: "#/components/parameters/RateOfInterestCode"
+        - $ref: "#/components/parameters/PurposeOfLoanCode"
+        - $ref: "#/components/parameters/TenureAgencyCode"
+        - $ref: "#/components/parameters/SizeClassCode"
+        - $ref: "#/components/parameters/SurveyYearCode"
+      responses:
+        "200":
+          description: >
+            Data fetched successfully. When no rows match, `data` is an empty
+            array, `msg` is "No Data Found", and `meta_data` is omitted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AidisRecord"
+                  meta_data:
+                    $ref: "#/components/schemas/MetaData"
+                  msg:
+                    type: string
+                    example: Data fetched successfully
+                  statusCode:
+                    type: boolean
+                    example: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/nss-77/getNss77AidisDownload:
+    get:
+      tags:
+        - NSS-77 AIDIS
+      summary: Generate AIDIS Excel download
+      description: >
+        Builds an XLSX file of the full (un-paginated) result set for the given
+        indicator + survey and optional filters, then returns its relative
+        path. Fails with 400 if the result set exceeds 50,000 rows.
+      parameters:
+        - $ref: "#/components/parameters/IndicatorCodeRequired"
+        - $ref: "#/components/parameters/SurveyCodeRequired"
+        - $ref: "#/components/parameters/SubIndicatorCode"
+        - $ref: "#/components/parameters/StateCode"
+        - $ref: "#/components/parameters/SectorCode"
+        - $ref: "#/components/parameters/GenderCode"
+        - $ref: "#/components/parameters/SocialGroupCode"
+        - $ref: "#/components/parameters/OccupationalCategoryCode"
+        - $ref: "#/components/parameters/HouseholdTypeCode"
+        - $ref: "#/components/parameters/QuintileClassCode"
+        - $ref: "#/components/parameters/AssetHoldingClassCode"
+        - $ref: "#/components/parameters/CreditAgencyCode"
+        - $ref: "#/components/parameters/NatureOfInterestCode"
+        - $ref: "#/components/parameters/RateOfInterestCode"
+        - $ref: "#/components/parameters/PurposeOfLoanCode"
+        - $ref: "#/components/parameters/TenureAgencyCode"
+        - $ref: "#/components/parameters/SizeClassCode"
+        - $ref: "#/components/parameters/SurveyYearCode"
+      responses:
+        "200":
+          description: >
+            File ready for download. When no rows match, `data` is an empty
+            array and `msg` is "No Data Found" (no file_path).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  file_path:
+                    type: string
+                    description: Relative path to the generated XLSX file.
+                    example: nss77Aidis/nss77Aidis_indicator_1_1717400000000_abc123.xlsx
+                  msg:
+                    type: string
+                    example: File ready for download
+                  statusCode:
+                    type: boolean
+                    example: true
+        "400":
+          description: >
+            Bad request — missing/invalid params, or result set exceeds the
+            50,000-row download limit.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+components:
+  parameters:
+    SurveyCodeRequired:
+      in: query
+      name: survey_code
+      required: true
+      description: Survey code (must exist in survey table).
+      schema:
+        type: integer
+        example: 1
+
+    IndicatorCodeRequired:
+      in: query
+      name: indicator_code
+      required: true
+      description: Indicator code (must exist in indicator table).
+      schema:
+        type: integer
+        example: 8
+
+    SubIndicatorCode:
+      in: query
+      name: sub_indicator_code
+      required: false
+      description: Optional sub-indicator code (validated against the indicator_code).
+      schema:
+        type: integer
+
+    Page:
+      in: query
+      name: page
+      required: false
+      description: Page number (1-based). Defaults to 1.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+
+    Limit:
+      in: query
+      name: limit
+      required: false
+      description: Records per page. Min 20, max 100. Defaults to 20.
+      schema:
+        type: integer
+        minimum: 20
+        maximum: 100
+        default: 20
+
+    StateCode:
+      in: query
+      name: state_code
+      required: false
+      description: Comma-separated state codes.
+      schema:
+        type: string
+        example: "1,2"
+
+    SectorCode:
+      in: query
+      name: sector_code
+      required: false
+      description: Comma-separated sector codes.
+      schema:
+        type: string
+
+    GenderCode:
+      in: query
+      name: gender_code
+      required: false
+      description: Comma-separated gender codes.
+      schema:
+        type: string
+
+    SocialGroupCode:
+      in: query
+      name: social_group_code
+      required: false
+      description: Comma-separated social group codes.
+      schema:
+        type: string
+
+    OccupationalCategoryCode:
+      in: query
+      name: occupational_category_code
+      required: false
+      description: Comma-separated occupational category codes.
+      schema:
+        type: string
+
+    HouseholdTypeCode:
+      in: query
+      name: household_type_code
+      required: false
+      description: Comma-separated household type codes.
+      schema:
+        type: string
+
+    QuintileClassCode:
+      in: query
+      name: quintile_class_code
+      required: false
+      description: Comma-separated quintile class codes.
+      schema:
+        type: string
+
+    AssetHoldingClassCode:
+      in: query
+      name: asset_holding_class_code
+      required: false
+      description: Comma-separated asset holding class codes.
+      schema:
+        type: string
+
+    CreditAgencyCode:
+      in: query
+      name: credit_agency_code
+      required: false
+      description: Comma-separated credit agency codes.
+      schema:
+        type: string
+
+    NatureOfInterestCode:
+      in: query
+      name: nature_of_interest_code
+      required: false
+      description: Comma-separated nature-of-interest codes.
+      schema:
+        type: string
+
+    RateOfInterestCode:
+      in: query
+      name: rate_of_interest_code
+      required: false
+      description: Comma-separated rate-of-interest codes.
+      schema:
+        type: string
+
+    PurposeOfLoanCode:
+      in: query
+      name: purpose_of_loan_code
+      required: false
+      description: Comma-separated purpose-of-loan codes.
+      schema:
+        type: string
+
+    TenureAgencyCode:
+      in: query
+      name: tenure_agency_code
+      required: false
+      description: Comma-separated tenure-agency codes.
+      schema:
+        type: string
+
+    SizeClassCode:
+      in: query
+      name: size_class_code
+      required: false
+      description: Comma-separated size-class codes.
+      schema:
+        type: string
+
+    SurveyYearCode:
+      in: query
+      name: survey_year_code
+      required: false
+      description: Comma-separated survey-year codes.
+      schema:
+        type: string
+
+  responses:
+    BadRequest:
+      description: Missing required parameter or invalid value.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            missingSurvey:
+              value:
+                error: "Missing required parameter: survey_code"
+                statusCode: false
+            invalidCode:
+              value:
+                error: "Invalid indicator_code"
+                statusCode: false
+
+    InternalServerError:
+      description: Unexpected server error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: Internal server error
+            statusCode: false
+
+  schemas:
+    Survey:
+      type: object
+      properties:
+        survey_code:
+          type: integer
+          example: 1
+        description:
+          type: string
+          example: AIDIS NSS 77th round
+
+    Indicator:
+      type: object
+      properties:
+        indicator_code:
+          type: integer
+          example: 8
+        description:
+          type: string
+          example: Average amount of debt
+        viz:
+          type: string
+          nullable: true
+
+    SubIndicator:
+      type: object
+      properties:
+        sub_indicator_code:
+          type: integer
+        description:
+          type: string
+
+    FilterOption:
+      type: object
+      description: A single dimension option. Some dimensions add extra keys (e.g. sector_code).
+      properties:
+        description:
+          type: string
+      additionalProperties: true
+
+    MetaData:
+      type: object
+      properties:
+        page:
+          type: integer
+          example: 1
+        totalRecords:
+          type: integer
+          example: 240
+        totalPages:
+          type: integer
+          example: 12
+        recordPerPage:
+          type: integer
+          example: 20
+
+    AidisRecord:
+      type: object
+      description: >
+        A data row. Dimension columns are nullable; when any filter is applied,
+        null-valued keys are stripped from the row.
+      properties:
+        indicator:
+          type: string
+        sub_indicator:
+          type: string
+        state:
+          type: string
+        sector:
+          type: string
+        gender:
+          type: string
+        social_group:
+          type: string
+        occupational_category:
+          type: string
+        household_type:
+          type: string
+        quintile_class:
+          type: string
+        asset_holding_class:
+          type: string
+        credit_agency:
+          type: string
+        nature_of_interest:
+          type: string
+        rate_of_interest:
+          type: string
+        purpose_of_loan:
+          type: string
+        tenure_agency:
+          type: string
+        size_class:
+          type: string
+        survey_year:
+          type: string
+        value:
+          type: number
+          nullable: true
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        statusCode:
+          type: boolean
+          example: false

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,4 +1,4 @@
-"""MCP Server health-check tests — all 4 tools across all 25 datasets.
+﻿"""MCP Server health-check tests ΓÇö all 4 tools across all 25 datasets.
 
 Uses FastMCP Client (in-process by default, HTTP via MCP_SERVER_URL env var).
 Run:  pytest tests/ -v
@@ -48,8 +48,8 @@ async def call(mcp_target, tool_name: str, arguments: dict, retries: int = 2) ->
 # Dataset definitions: each tuple is
 #   (dataset, step3_kwargs, step4_filters)
 #
-# step3_kwargs  — extra keyword args for get_metadata (beyond 'dataset')
-# step4_filters — the 'filters' dict for get_data
+# step3_kwargs  ΓÇö extra keyword args for get_metadata (beyond 'dataset')
+# step4_filters ΓÇö the 'filters' dict for get_data
 # ---------------------------------------------------------------------------
 
 DATASETS = [
@@ -133,8 +133,8 @@ DATASETS = [
     ),
     pytest.param(
         "NSS77",
-        {"indicator_code": 16},
-        {"indicator_code": "16", "limit": "1"},
+        {"indicator_code": 21},
+        {"indicator_code": "21", "limit": "1"},
         id="NSS77",
     ),
     pytest.param(
@@ -223,7 +223,7 @@ _INTERNAL_KEYS = {"user_query", "next_step", "related_datasets"}
 
 
 # ---------------------------------------------------------------------------
-# Tool registration — verify the server exposes exactly 4 tools
+# Tool registration ΓÇö verify the server exposes exactly 4 tools
 # ---------------------------------------------------------------------------
 
 
@@ -251,7 +251,7 @@ async def test_list_datasets(mcp_target):
 
 
 # ---------------------------------------------------------------------------
-# get_indicators — one test per dataset
+# get_indicators ΓÇö one test per dataset
 # ---------------------------------------------------------------------------
 
 
@@ -288,7 +288,7 @@ async def test_get_indicators_does_not_reflect_user_query(mcp_target):
 
 
 # ---------------------------------------------------------------------------
-# get_metadata — one test per dataset
+# get_metadata ΓÇö one test per dataset
 # ---------------------------------------------------------------------------
 
 
@@ -309,7 +309,7 @@ async def test_get_metadata(mcp_target, dataset, step3_kwargs, step4_filters):
 
 
 # ---------------------------------------------------------------------------
-# get_data — one test per dataset
+# get_data ΓÇö one test per dataset
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Merges portal **nss77a** (AIDIS — All India Debt & Investment Survey) into existing **NSS77** MCP dataset
- Single dataset remains `NSS77` — total datasets stay at **25**
- **55 indicators** total: 33 Land & Livestock + 22 AIDIS
- Module routing: `module=land_livestock` or `module=aidis`
- **Required** for overlapping codes: 16–19, 24, 26, 29, 32, 34, 36

## Changes
- `mospi/client.py` — dual-module indicators, filters, data routing (AIDIS limit 20–100)
- `mospi_server.py` — `module` param, AIDIS swagger merge with `$ref` resolution
- `swagger/swagger_user_nss77.yaml` + `swagger/swagger_user_nss77_aidis.yaml`
- `definitions/nss77_aidis_definitions.json`
- `tests/test_mcp_server.py` — NSS77 uses indicator 21 (non-overlapping)
- `README.md`, `CHANGELOG.md`

## Test plan
- [x] `pytest tests/test_mcp_server.py` — 84/84 passed
- [ ] After merge: `./deploy.sh` on production
- [ ] `get_indicators("NSS77")` → 55 indicators with `module` field
- [ ] AIDIS sample: `get_data("NSS77", {"module":"aidis","indicator_code":"2","state_code":"37","limit":"20"})`