### PR TITLE
Add ISP dataset with DB-aligned swagger and metadata filters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ISP (Index of Service Production) with services sector output indices. Base year 2024-25. frequency_code: 1=Yearly, 2=Monthly (default). year in YYYY-YY financial year format; month_code uses Indian FY (1=April ... 12=March). Covers 19 broad sub-sectors (~60% of services GVA). Filters: base_year, frequency_code, year, month_code, type_code, broad_sub_sector_code, broad_sub_sector_category_code, nic_2_digit_code. Data endpoint: `/api/isp/getISPRecords`. Filter metadata via `/api/isp/getISPFilter` with fallback to data endpoint probe.
 - NSS75E (NSS 75th Round - Education / Social Consumption on Education) with 13 indicators (survey_code=2, codes 43-55): literacy rate, educational attainment, mean years of schooling, GAR/NAR, student attendance and course-type distribution, average student expenditure by course and expenditure item, and household computer/internet access. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-75/getNSS75FilterByIndicatorId`.
 - NSS76 (NSS 76th Round - Disability + Housing & Drinking Water) with 25 indicators across two modules: survey_code=1 (Disability, indicators 1-13) covering disability prevalence, literacy, education, employment, care arrangements, and receipt of aid/help; survey_code=2 (Housing & drinking water, indicators 14-26) covering drinking water sources, sufficiency, treatment, housing characteristics, latrines, and flood experience. survey_code is auto-derived from indicator_code when omitted. Filter metadata uses `/api/nss-76/getNSS76FilterByIndicatorId` (swagger documents data endpoint only).
 
@@ -15,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ENERGY swagger updated from portal (v1.0.11): relaxed filter param patterns; year accepts YYYY-YY and YYYY; documented Supply/Consumption and indicator description strings for get_data.
 - NAS swagger updated from portal (v1.0.11): `account_code` filter (01-02), comma-separated `indicator_code`, clarified base_year/series rules (2011-12 → Current+Back; 2022-23 → Current only).
 - NSS77 expanded to include AIDIS module (portal nss77a): 55 total indicators across `module=land_livestock` (33 indicators) and `module=aidis` (22 indicators, survey_code=1). Official AIDIS swagger (`swagger_user_nss77_aidis.yaml`) merged for filter validation. Module routing with auto-derivation for non-overlapping indicator codes.
+- Total datasets: 25 → 26 (ISP)
+- list_datasets, get_indicators, and get_metadata updated to include ISP
 - Total datasets: 23 → 25 (NSS76, NSS75E)
 - list_datasets, get_indicators, and get_metadata updated to include NSS76 and NSS75E
 - Upgraded fastmcp from 3.0.0b1 to 3.3.1, moving from a beta to a stable release. The mcp SDK is now resolved transitively by fastmcp and is no longer pinned in requirements.txt.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Adding a New Dataset
 
-The server currently supports 25 datasets. To add a new one:
+The server currently supports 26 datasets. To add a new one:
 
 ### 1. Get the Swagger spec
 
@@ -111,7 +111,7 @@ pip install -r tests/requirements-test.txt
 pytest tests/ -v -p no:anyio
 ```
 
-This runs tests covering all 25 datasets across all 4 tools, plus negative/error-path tests. Tests hit the live MoSPI API with a 0.5s throttle between calls to avoid rate-limiting.
+This runs tests covering all 26 datasets across all 4 tools, plus negative/error-path tests. Tests hit the live MoSPI API with a 0.5s throttle between calls to avoid rate-limiting.
 
 To test against a deployed server instead of in-process:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ MCP (Model Context Protocol) server for accessing India's Ministry of Statistics
 This server provides AI-ready access to official Indian government statistics through the Model Context Protocol (MCP). It acts as a bridge between AI assistants (Claude, ChatGPT, Cursor, etc.) and MoSPI's open data APIs, enabling natural language queries for economic, demographic, and social indicators.
 
 **Key Features:**
-- 25 statistical datasets covering employment, inflation, industrial production, GDP, energy, renewable energy, higher education, school education, gender, health, disability, housing, NSS education consumption, environment, trade, agriculture, consumption, economic census, and digital literacy
+- 26 statistical datasets covering employment, inflation, industrial production, services production, GDP, energy, renewable energy, higher education, school education, gender, health, disability, housing, NSS education consumption, environment, trade, agriculture, consumption, economic census, and digital literacy
 - Sequential 4-tool workflow designed for LLM consumption
 - Swagger-driven parameter validation
 - Full OpenTelemetry integration for observability
@@ -62,6 +62,7 @@ This server provides AI-ready access to official Indian government statistics th
 | **PLFS** | Periodic Labour Force Survey | Jobs, unemployment, wages, workforce participation |
 | **CPI** | Consumer Price Index | Retail inflation, cost of living, commodity prices |
 | **IIP** | Index of Industrial Production | Industrial growth, manufacturing output |
+| **ISP** | Index of Service Production | Services sector growth, monthly services output, sub-sector indices |
 | **ASI** | Annual Survey of Industries | Factory performance, industrial employment |
 | **NAS** | National Accounts Statistics | GDP, economic growth, national income |
 | **WPI** | Wholesale Price Index | Wholesale inflation, producer prices |

--- a/mospi/client.py
+++ b/mospi/client.py
@@ -69,6 +69,7 @@ class MoSPI:
             "CPI_Group": "/api/cpi/getCPIIndex",
             "CPI_Item": "/api/cpi/getItemIndex",
             "IIP": "/api/iip/getIipData",
+            "ISP": "/api/isp/getISPRecords",
             "ASI": "/api/asi/getASIData",
             "NAS": "/api/nas/getNASData",
             "WPI": "/api/wpi/getWpiRecords",
@@ -467,6 +468,90 @@ class MoSPI:
                 f"{self.base_url}/api/nas/getNasFilterByIndicatorId",
                 params=params,
                 timeout=30
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as e:
+            return {"error": str(e), "statusCode": False}
+
+    # =========================================================================
+    # ISP Metadata Methods
+    # =========================================================================
+
+    def get_isp_indicators(self) -> Dict[str, Any]:
+        """Return ISP dataset overview and frequency options."""
+        return {
+            "data": [
+                {
+                    "name": "Index of Service Production (ISP)",
+                    "description": (
+                        "Monthly index measuring short-term changes in formal services "
+                        "sector output. Counterpart to IIP for services. Base year 2024-25. "
+                        "Covers 19 sub-sectors (~60% of services GVA) including wholesale "
+                        "and retail trade, transport, telecommunications, real estate, "
+                        "professional services, and more."
+                    ),
+                }
+            ],
+            "base_years": [{"code": "2024-25", "name": "2024-25 (current)"}],
+            "frequency": [
+                {"code": 1, "name": "Yearly"},
+                {"code": 2, "name": "Monthly"},
+            ],
+            "_note": (
+                "ISP is released monthly with ~60-day lag. "
+                "frequency_code: 1=Yearly, 2=Monthly (default). "
+                "year uses financial year format YYYY-YY (e.g. 2025-26). "
+                "month_code follows Indian FY: 1=April ... 12=March. "
+                "Use get_metadata(dataset='ISP') for valid filter values."
+            ),
+            "statusCode": True,
+        }
+
+    def get_isp_filters(
+        self,
+        frequency_code: int = 2,
+        base_year: str = "2024-25",
+    ) -> Dict[str, Any]:
+        """Fetch available ISP filters for a given frequency and base year.
+
+        Args:
+            frequency_code: 1=Yearly, 2=Monthly (default)
+            base_year: Index base year (default "2024-25")
+        """
+        params = {
+            "frequency_code": frequency_code,
+            "base_year": base_year,
+        }
+        filter_endpoints = (
+            "/api/isp/getISPFilter",
+            "/api/isp/getIspFilter",
+        )
+        for endpoint in filter_endpoints:
+            try:
+                response = self.session.get(
+                    f"{self.base_url}{endpoint}",
+                    params=params,
+                    timeout=30,
+                )
+                if response.status_code == 404:
+                    continue
+                response.raise_for_status()
+                result = response.json()
+                if result.get("data") or result.get("statusCode"):
+                    return result
+            except requests.RequestException:
+                continue
+
+        try:
+            response = self.session.get(
+                f"{self.base_url}/api/isp/getISPRecords",
+                params={
+                    "base_year": base_year,
+                    "frequency_code": frequency_code,
+                    "limit": 1,
+                },
+                timeout=30,
             )
             response.raise_for_status()
             return response.json()

--- a/mospi_server.py
+++ b/mospi_server.py
@@ -96,7 +96,7 @@ mcp.add_middleware(TelemetryMiddleware())
 
 
 VALID_DATASETS = [
-    "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
+    "PLFS", "CPI", "IIP", "ISP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
     "NSS77", "NSS78", "NSS76", "NSS75E", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80"
 ]
@@ -109,6 +109,7 @@ DATASET_SWAGGER = {
     "CPI_GROUP": ("swagger_user_cpi.yaml", "/api/cpi/getCPIIndex"),
     "CPI_ITEM": ("swagger_user_cpi.yaml", "/api/cpi/getItemIndex"),
     "IIP": ("swagger_user_iip.yaml", "/api/iip/getIipData"),
+    "ISP": ("swagger_user_isp.yaml", "/api/isp/getISPRecords"),
     "ASI": ("swagger_user_asi.yaml", "/api/asi/getASIData"),
     "NAS": ("swagger_user_nas.yaml", "/api/nas/getNASData"),
     "WPI": ("swagger_user_wpi.yaml", "/api/wpi/getWpiRecords"),
@@ -318,10 +319,10 @@ def get_indicators(
     Step 2 of: list_datasets ΓåÆ get_indicators ΓåÆ get_metadata ΓåÆ get_data
 
     Args:
-        dataset: Dataset name ΓÇö one of: PLFS, CPI, IIP, ASI, NAS, WPI,
+        dataset: Dataset name ΓÇö one of: PLFS, CPI, IIP, ISP, ASI, NAS, WPI,
                  ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI,
                  NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
-                 For CPI, IIP, WPI: returns available base years and frequencies.
+                 For CPI, IIP, ISP, WPI: returns available base years and frequencies.
         user_query: The user's original question. Captured for telemetry analytics; not echoed back in the response.
 
     Returns:
@@ -360,6 +361,7 @@ def get_indicators(
         # Special datasets - return guidance instead of indicators
         "CPI": mospi.get_cpi_base_years,
         "IIP": mospi.get_iip_base_years,
+        "ISP": mospi.get_isp_indicators,
         "WPI": mospi.get_wpi_base_years,
         "ASI": mospi.get_asi_indicators,
     }
@@ -374,6 +376,7 @@ def get_indicators(
     result["related_datasets"] = (
         "Datasets with overlapping coverage: "
         "IIP (production index, growth rates) vs ASI (factory financials: capital, wages, GVA). "
+        "IIP (industrial production) vs ISP (services production). "
         "CPI (consumer inflation) vs WPI (wholesale inflation)."
     )
     return result
@@ -413,7 +416,7 @@ def get_metadata(
         dataset: Dataset name (same values as get_indicators).
         indicator_code: Required for: PLFS, NAS, ENERGY, AISHE, ASUSE, GENDER,
                         NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80.
-                        Not applicable for: CPI, IIP, ASI, WPI.
+                        Not applicable for: CPI, IIP, ISP, ASI, WPI.
                         For RBI, this maps to sub_indicator_code internally.
         frequency_code: Required for PLFS and ASUSE.
                         PLFS: 1=Annual, 2=Quarterly bulletin, 3=Monthly.
@@ -482,6 +485,28 @@ def get_metadata(
                 "frequency='Monthly': use year (YYYY) and month_code params."
             )
             return _check_empty_metadata(result, dataset, base_year=base_year, frequency=frequency)
+
+        elif dataset == "ISP":
+            fc = frequency_code if frequency_code is not None else 2
+            by = base_year or "2024-25"
+            result = mospi.get_isp_filters(frequency_code=fc, base_year=by)
+            result["api_params"] = get_swagger_param_definitions("ISP")
+            result["next_step"] = _next
+            result["parameter_notes"] = (
+                "Index of Service Production (ISP) measures output in India's formal "
+                "services sector. base_year='2024-25' (current). "
+                "frequency_code: 1=Yearly, 2=Monthly (default). "
+                "year uses financial year format YYYY-YY (e.g. 2025-26, 2026-27). "
+                "month_code (Indian FY): 1=April ... 12=March; use only when frequency_code=2. "
+                "type_code: 1=General, 2=Broad Sub Sector. "
+                "broad_sub_sector_code: 1-19 sub-sectors. "
+                "Optional: broad_sub_sector_category_code, nic_2_digit_code."
+            )
+            result["base_year_coverage"] = (
+                f"Current base_year='{by}', frequency_code={fc}. "
+                "Only base_year='2024-25' is available at present."
+            )
+            return _check_empty_metadata(result, dataset, frequency_code=fc, base_year=by)
 
         elif dataset == "ASI":
             result = mospi.get_asi_filters(classification_year=classification_year or "2008")
@@ -783,7 +808,7 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
     Step 4 of: list_datasets ΓåÆ get_indicators ΓåÆ get_metadata ΓåÆ get_data
 
     Args:
-        dataset: Dataset name (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY,
+        dataset: Dataset name (PLFS, CPI, IIP, ISP, ASI, NAS, WPI, ENERGY,
                  AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77,
                  NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80).
                  CPI auto-routes to Group or Item endpoint based on
@@ -821,6 +846,7 @@ def get_data(dataset: str, filters: Dict[str, Any]) -> dict:
         "CPI_GROUP": "CPI_Group",
         "CPI_ITEM": "CPI_Item",
         "IIP": "IIP",
+        "ISP": "ISP",
         "PLFS": "PLFS",
         "ASI": "ASI",
         "NAS": "NAS",
@@ -956,7 +982,7 @@ def list_datasets() -> dict:
         and 'workflow' (the four-step sequence).
     """
     return {
-        "total_datasets": 25,
+        "total_datasets": 26,
         "datasets": {
             "PLFS": {
                 "name": "Periodic Labour Force Survey",
@@ -972,6 +998,11 @@ def list_datasets() -> dict:
                 "name": "Index of Industrial Production",
                 "description": "Category-based structure with base years (1993-94, 2004-05, 2011-12) and frequency options (monthly/annual). Measures industrial output across manufacturing, mining, and electricity sectors using use-based classification (basic goods, capital goods, intermediate goods, consumer durables/non-durables).",
                 "use_for": "IIP index, industrial production index, manufacturing index, mining/electricity index, growth rates, textiles, metals, vehicles, consumer durables, capital goods"
+            },
+            "ISP": {
+                "name": "Index of Service Production",
+                "description": "Index measuring short-term changes in formal services sector output. Base year 2024-25. frequency_code: 1=Yearly, 2=Monthly. year in YYYY-YY financial year format. month_code uses Indian FY (1=April ... 12=March). Covers 19 broad sub-sectors (~60% of services GVA). Optional filters: type_code, broad_sub_sector_category_code, nic_2_digit_code. Counterpart to IIP for the services sector.",
+                "use_for": "Services production index, services sector growth, monthly services output, trade/transport/telecom/real estate sub-sector indices, formal services sector activity"
             },
             "ASI": {
                 "name": "Annual Survey of Industries",
@@ -1101,7 +1132,7 @@ if __name__ == "__main__":
     log("="*75)
     log("Serving Indian Government Statistical Data")
     log("Framework: FastMCP 3.3 with OpenTelemetry")
-    log("Datasets: 25 (PLFS, CPI, IIP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80)")
+    log("Datasets: 26 (PLFS, CPI, IIP, ISP, ASI, NAS, WPI, ENERGY, AISHE, ASUSE, GENDER, NFHS, ENVSTATS, RBI, NSS77, NSS78, NSS76, NSS75E, NSS79, CPIALRL, HCES, TUS, EC, UDISE, MNRE, NSS80)")
     log("Server: http://localhost:8000/mcp")
     log("Telemetry: IP tracking + Input/Output capture enabled")
     log("="*75 + "\n")

--- a/swagger/swagger_user_isp.yaml
+++ b/swagger/swagger_user_isp.yaml
@@ -1,0 +1,156 @@
+openapi: 3.0.1
+
+info:
+  title: API for Index of Service Production (ISP)
+  version: 1.0.0
+
+servers:
+  - url: https://api.mospi.gov.in/
+
+tags:
+  - name: Index of Service Production
+    description: ISP API for Index of Service Production statistics
+
+paths:
+  /api/isp/getISPRecords:
+    get:
+      tags:
+        - Index of Service Production
+
+      summary: Get ISP Data
+
+      description: >
+        API to fetch Index of Service Production (ISP) data measuring short-term
+        changes in formal services sector output. Base year 2024-25.
+
+        Optional filters:
+        base_year, frequency_code, year, month_code, type_code,
+        broad_sub_sector_code, broad_sub_sector_category_code, nic_2_digit_code,
+        limit, page
+
+        Response fields include base_year, year, index, growth_rate, and dimension labels.
+
+      parameters:
+        - in: query
+          name: base_year
+          schema:
+            type: string
+            default: "2024-25"
+            enum:
+              - "2024-25"
+          description: Base year for the index (default and current value is "2024-25").
+
+        - in: query
+          name: frequency_code
+          schema:
+            type: integer
+            default: 2
+            enum:
+              - 1
+              - 2
+          description: "1=Yearly, 2=Monthly. Default to 2 (Monthly) for recent sub-sector indices."
+
+        - in: query
+          name: year
+          schema:
+            type: string
+            pattern: ^\d{4}-\d{2}(,\d{4}-\d{2})*$
+          description: >
+            Financial year in YYYY-YY format (e.g. "2025-26", "2026-27").
+            Comma separated for multiple values.
+
+        - in: query
+          name: month_code
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+              - 4
+              - 5
+              - 6
+              - 7
+              - 8
+              - 9
+              - 10
+              - 11
+              - 12
+          description: >
+            Indian financial year month code. Use only when frequency_code=2 (Monthly).
+            1=April, 2=May, 3=June, 4=July, 5=August, 6=September,
+            7=October, 8=November, 9=December, 10=January, 11=February, 12=March.
+
+        - in: query
+          name: type_code
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+          description: "1=General, 2=Broad Sub Sector."
+
+        - in: query
+          name: broad_sub_sector_code
+          schema:
+            type: integer
+          description: >
+            Broad sub-sector code (1-19). Covers wholesale/retail trade, transport,
+            telecom, banking, insurance, real estate, IT, professional services, etc.
+
+        - in: query
+          name: broad_sub_sector_category_code
+          schema:
+            type: integer
+          description: Broad sub-sector category code (refer metadata sheet).
+
+        - in: query
+          name: nic_2_digit_code
+          schema:
+            type: integer
+          description: NIC 2-digit sub-sector code (refer metadata sheet).
+
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 10
+          description: Number of records per page (default 10).
+
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+          description: Page number (from 1 to n).
+
+        - in: query
+          name: Format
+          schema:
+            type: string
+            default: JSON
+            enum:
+              - JSON
+              - CSV
+          description: Output format (JSON or CSV).
+
+      responses:
+        "200":
+          description: Successful response with ISP index and growth_rate values.
+
+        "400":
+          description: Invalid parameters
+
+        "409":
+          description: No data found
+
+      security:
+        - bearerAuth: []
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Bearer token to access the API

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -78,6 +78,12 @@ DATASETS = [
         id="IIP",
     ),
     pytest.param(
+        "ISP",
+        {"base_year": "2024-25", "frequency_code": 2},
+        {"base_year": "2024-25", "frequency_code": "2", "limit": "1"},
+        id="ISP",
+    ),
+    pytest.param(
         "ASI",
         {"classification_year": "2008"},
         {"classification_year": "2008", "sector_code": "Combined", "nic_type": "All", "limit": "1"},
@@ -219,7 +225,7 @@ EXPECTED_TOOLS = {
 }
 
 EXPECTED_DATASETS = {
-    "PLFS", "CPI", "IIP", "ASI", "NAS", "WPI", "ENERGY",
+    "PLFS", "CPI", "IIP", "ISP", "ASI", "NAS", "WPI", "ENERGY",
     "AISHE", "ASUSE", "GENDER", "NFHS", "ENVSTATS", "RBI",
     "NSS77", "NSS78", "NSS76", "NSS75E", "NSS79", "CPIALRL", "HCES", "TUS", "EC", "UDISE", "MNRE", "NSS80",
 }


### PR DESCRIPTION
## Summary
- Adds ISP (Index of Service Production) as the 26th dataset in esankhyiki-mcp
- Swagger aligned with ISP DB schema: base_year, frequency_code (1=Yearly, 2=Monthly), financial year format, month_code (Indian FY), type_code, nic_2_digit_code
- Client + server wiring, tests, README/CHANGELOG updates

## Test plan
- [x] `pytest tests/test_consistency.py` — 10/10 passed
- [x] `pytest tests/test_mcp_server.py -k ISP` — 3/3 passed (get_indicators, get_metadata, get_data)
- [ ] Reviewer: verify live MoSPI API returns ISP data with `frequency_code=2`